### PR TITLE
feat(transaction): skip error transaction on GetConfirmations

### DIFF
--- a/src/Methods/Transactions/GetConfirmations.ts
+++ b/src/Methods/Transactions/GetConfirmations.ts
@@ -10,15 +10,19 @@ export default method({
   handler: async ({ ids }) => {
     const confirmations: Confirmation[] = [];
     for (const id of ids) {
-      const transaction = await rpc.transactions.getRawTransaction(id, true);
-      if (!transaction) {
-        continue;
+      try{
+        const transaction = await rpc.transactions.getRawTransaction(id, true);
+        if (!transaction) {
+          continue;
+        }
+        confirmations.push({
+          txid: transaction.txid,
+          confirmations: transaction.confirmations ?? -1,
+          timestamp: transaction.time || transaction.locktime,
+        });
+      } catch (_) {
+        // on transaction not found/error => skip
       }
-      confirmations.push({
-        txid: transaction.txid,
-        confirmations: transaction.confirmations ?? -1,
-        timestamp: transaction.time || transaction.locktime,
-      });
     }
     return confirmations;
   },


### PR DESCRIPTION
## What changed?

calling `Transactions.GetConfirmations` with a single invalid transaction will cause RPC to throw error. Ideally, this batch RPC should skip ids that are returning errors and only return those that are valid.

Added Try Catch to skip error