### PR TITLE
feat(rpc): add GetTransactionsInBulk + add GetInscriptionsTransactions

### DIFF
--- a/src/Libraries/Limiter.ts
+++ b/src/Libraries/Limiter.ts
@@ -10,6 +10,9 @@ export function limiter<T>(concurrency: number) {
     run: async (): Promise<T[]> => {
       return await Promise.all(input);
     },
+    runSettled: async (): Promise<PromiseSettledResult<T>[]> => {
+      return await Promise.allSettled(input);
+    },
     length: () => {
       return input.length
     }

--- a/src/Methods/Ordinals/GetInscriptionsTransactions.ts
+++ b/src/Methods/Ordinals/GetInscriptionsTransactions.ts
@@ -1,0 +1,45 @@
+import { method } from "@valkyr/api";
+import Schema, { string } from "computed-types";
+
+import { config } from "../../Config";
+import { db } from "../../Database";
+import { schema } from "../../Libraries/Schema";
+import { getExpandedTransaction, parseLocation } from "../../Utilities/Transaction";
+import { rpc } from "~Services/Bitcoin";
+
+export default method({
+  params: Schema({
+    filter: Schema({
+      owner: string.optional(),
+    }).optional(),
+    sort: schema.sort.optional(),
+    pagination: schema.pagination.optional(),
+  }),
+  handler: async ({ filter = {}, sort = {}, pagination = {} }) => {
+    const result = await db.inscriptions.findPaginated({
+      ...pagination,
+      filter,
+      sort,
+      transform: (inscription) => {
+        inscription.mediaContent = `${config.api.uri}/content/${inscription.id}`;
+      },
+    });
+    // get transactions
+    const inscriptionsWithTransactions = await Promise.all(
+      result.documents.map(async (inscription) => {
+        const [txid] = parseLocation(inscription.outpoint);
+        const tx = await rpc.transactions.getRawTransaction(txid, true);
+        const expandedTx = await getExpandedTransaction(tx);
+        return {
+          ...inscription,
+          transaction: expandedTx,
+        };
+      }),
+    );
+
+    return {
+      inscriptions: inscriptionsWithTransactions,
+      pagination: result.pagination,
+    };
+  },
+});

--- a/src/Methods/Transactions/GetTransactionsInBulk.ts
+++ b/src/Methods/Transactions/GetTransactionsInBulk.ts
@@ -1,0 +1,28 @@
+import { method } from "@valkyr/api";
+import Schema, { array, boolean, string } from "computed-types";
+
+import { rpc } from "../../Services/Bitcoin";
+import { getExpandedTransaction } from "../../Utilities/Transaction";
+
+const options = Schema({
+  ord: boolean.optional(),
+  hex: boolean.optional(),
+  witness: boolean.optional(),
+});
+
+export default method({
+  params: Schema({
+    txIds: array.of(string),
+    options: options.optional(),
+  }),
+  handler: async ({ txIds, options }) => {
+    const expandedTxs = await Promise.allSettled(
+      txIds.map(async (txId) => {
+        const tx = await rpc.transactions.getRawTransaction(txId, true);
+        return getExpandedTransaction(tx, options);
+      }),
+    );
+    // remove the failed promises
+    return expandedTxs.filter((tx) => tx.status === "fulfilled").map((tx) => tx.status === "fulfilled" && tx.value);
+  },
+});


### PR DESCRIPTION
1. Add `GetTransactionsInBulk` that accepts a list of `txIds` returns all transactions data.
2. Add `GetInscriptionsTransactions` that returns inscriptions data along with the outpoint tx (latest tx)