### PR TITLE
fix(indexer): support index multiple inscriptions in witness

### DIFF
--- a/src/Database/Inscriptions/Collection.ts
+++ b/src/Database/Inscriptions/Collection.ts
@@ -56,6 +56,7 @@ export const registrar: CollectionRegistrar = {
 export type Inscription = {
   id: string;
   parent?: string;
+  delegate?: string;
   children: string[];
   creator: string;
   owner?: string;

--- a/src/Libraries/Inscriptions/Envelope.ts
+++ b/src/Libraries/Inscriptions/Envelope.ts
@@ -13,6 +13,7 @@ const TYPE_TAG = 81;
 const PARENT_TAG = 83;
 const META_TAG = 85;
 const BODY_TAG = 0;
+const DELEGATE_TAG = 91;
 
 type EnvelopeData = number | Buffer;
 
@@ -27,6 +28,7 @@ export class Envelope {
   readonly protocol?: string;
   readonly type?: string;
   readonly parent?: string;
+  readonly delegate?: string;
   readonly content?: {
     size: number;
     body: string;
@@ -49,6 +51,7 @@ export class Envelope {
     this.protocol = getEnvelopeProtocol(data);
     this.type = getEnvelopeType(data);
     this.parent = getParent(data);
+    this.delegate = getDelegateTag(data);
     this.content = getEnvelopeContent(data);
     this.media = getMediaMeta(this.type);
     this.meta = getEnvelopeMeta(data) ?? {};
@@ -168,6 +171,18 @@ function getParent(data: EnvelopeData[]) {
     return undefined;
   }
   return `${parent.reverse().toString("hex")}i0`;
+}
+
+function getDelegateTag(data: EnvelopeData[]) {
+  const startIndex = data.indexOf(DELEGATE_TAG);
+  if (startIndex === -1) {
+    return undefined;
+  }
+  const delegate = data[startIndex + 1];
+  if (!delegate || !isBuffer(delegate)) {
+    return undefined;
+  }
+  return `${delegate.reverse().toString("hex")}i0`;
 }
 
 function getEnvelopeMeta(data: EnvelopeData[]) {

--- a/src/Libraries/Inscriptions/Envelope.ts
+++ b/src/Libraries/Inscriptions/Envelope.ts
@@ -61,9 +61,9 @@ export class Envelope {
    * @param tx - Raw bitcoin transaction to search for an inscription envelope
    */
   static fromTransaction(tx: RawTransaction) {
-    const envelops = getEnvelopesDataFromTx(tx);
-    if (envelops) {
-      return envelops.map(([data, oip], index) => {
+    const envelopes = getEnvelopesDataFromTx(tx);
+    if (envelopes) {
+      return envelopes.map(([data, oip], index) => {
         if (data) {
           return new Envelope(tx.txid, data, oip, index);
         }
@@ -73,9 +73,9 @@ export class Envelope {
   }
 
   static fromTxinWitness(txid: string, txinwitness: string[]) {
-    const envelops = getEnvelopesFromTxinWitness(txinwitness);
-    if (envelops) {
-      return envelops.map(([data, oip], index) => {
+    const envelopes = getEnvelopesFromTxinWitness(txinwitness);
+    if (envelopes) {
+      return envelopes.map(([data, oip], index) => {
         if (data) {
           return new Envelope(txid, data, oip, index);
         }
@@ -213,12 +213,12 @@ function getEnvelopesFromTxinWitness(txinwitness: string[]): [EnvelopeData[]?, a
       if (data) {
         const oip = getMetaFromWitness(txinwitness);
         if (oip) {
-          return getEnvelopes(data).map((envelop) => {
-            return [envelop, oip];
+          return getEnvelopes(data).map((envelope) => {
+            return [envelope, oip];
           });
         }
-        return getEnvelopes(data).map((envelop) => {
-          return [envelop];
+        return getEnvelopes(data).map((envelope) => {
+          return [envelope];
         });
       }
     }
@@ -234,7 +234,7 @@ function getEnvelopesFromTxinWitness(txinwitness: string[]): [EnvelopeData[]?, a
  * @param data - Witness script to extract envelope from.
  */
 function getEnvelopes(data: EnvelopeData[]): EnvelopeData[][] {
-  const envelops: EnvelopeData[][] = [];
+  const envelopes: EnvelopeData[][] = [];
 
   let startIndex = -1;
   let endIndex = -1;
@@ -248,15 +248,15 @@ function getEnvelopes(data: EnvelopeData[]): EnvelopeData[][] {
     if (data[i] === ENVELOPE_END_TAG && startIndex !== -1) {
       endIndex = i;
 
-      envelops.push(data.slice(startIndex + 1, endIndex));
+      envelopes.push(data.slice(startIndex + 1, endIndex));
 
-      // reset for the next envelop
+      // reset for the next envelope
       startIndex = -1;
       endIndex = -1;
     }
   }
 
-  return envelops;
+  return envelopes;
 }
 
 /*

--- a/src/Libraries/Inscriptions/Envelope.ts
+++ b/src/Libraries/Inscriptions/Envelope.ts
@@ -62,7 +62,7 @@ export class Envelope {
    */
   static fromTransaction(tx: RawTransaction) {
     const envelopes = getEnvelopesDataFromTx(tx);
-    if (envelopes) {
+    if (envelopes && envelopes.length > 0) {
       return envelopes.map(([data, oip], index) => {
         if (data) {
           return new Envelope(tx.txid, data, oip, index);
@@ -74,7 +74,7 @@ export class Envelope {
 
   static fromTxinWitness(txid: string, txinwitness: string[]) {
     const envelopes = getEnvelopesFromTxinWitness(txinwitness);
-    if (envelopes) {
+    if (envelopes && envelopes.length > 0) {
       return envelopes.map(([data, oip], index) => {
         if (data) {
           return new Envelope(txid, data, oip, index);

--- a/src/Libraries/Inscriptions/Envelope.ts
+++ b/src/Libraries/Inscriptions/Envelope.ts
@@ -67,7 +67,7 @@ export class Envelope {
         if (data) {
           return new Envelope(tx.txid, data, oip, index);
         }
-        return null;
+        return undefined;
       });
     }
   }
@@ -79,7 +79,7 @@ export class Envelope {
         if (data) {
           return new Envelope(txid, data, oip, index);
         }
-        return null;
+        return undefined;
       });
     }
   }

--- a/src/Libraries/Inscriptions/Inscription.ts
+++ b/src/Libraries/Inscriptions/Inscription.ts
@@ -45,7 +45,7 @@ export class Inscription {
 
   static async fromTransaction(tx: RawTransaction) {
     const envelopes = Envelope.fromTransaction(tx);
-    if (envelopes) {
+    if (envelopes && envelopes.length > 0) {
       return envelopes.map((envelope) => {
         if (envelope?.isValid) {
           return envelope;
@@ -57,7 +57,7 @@ export class Inscription {
 
   static async fromVin(vin: VinData) {
     const envelopes = Envelope.fromTxinWitness(vin.txid, vin.witness);
-    if (envelopes) {
+    if (envelopes && envelopes.length > 0) {
       return envelopes.map((envelope) => {
         if (envelope?.isValid) {
           return envelope;

--- a/src/Libraries/Inscriptions/Inscription.ts
+++ b/src/Libraries/Inscriptions/Inscription.ts
@@ -44,16 +44,26 @@ export class Inscription {
   }
 
   static async fromTransaction(tx: RawTransaction) {
-    const envelope = Envelope.fromTransaction(tx);
-    if (envelope && envelope.isValid) {
-      return envelope;
+    const envelopes = Envelope.fromTransaction(tx);
+    if (envelopes) {
+      return envelopes.map((envelope) => {
+        if (envelope?.isValid) {
+          return envelope;
+        }
+        return undefined;
+      });
     }
   }
 
   static async fromVin(vin: VinData) {
-    const envelope = Envelope.fromTxinWitness(vin.txid, vin.witness);
-    if (envelope && envelope.isValid) {
-      return envelope;
+    const envelopes = Envelope.fromTxinWitness(vin.txid, vin.witness);
+    if (envelopes) {
+      return envelopes.map((envelope) => {
+        if (envelope?.isValid) {
+          return envelope;
+        }
+        return undefined;
+      });
     }
   }
 }

--- a/src/Libraries/Inscriptions/Inscription.ts
+++ b/src/Libraries/Inscriptions/Inscription.ts
@@ -9,6 +9,7 @@ import { Envelope } from "./Envelope";
 export class Inscription {
   readonly id: string;
   readonly parent?: string;
+  readonly delegate?: string;
   readonly children?: string[];
   readonly genesis: string;
   readonly creator: string;
@@ -27,6 +28,7 @@ export class Inscription {
   constructor(data: InscriptionData) {
     this.id = data.id;
     this.parent = data.parent;
+    this.delegate = data.delegate;
     this.children = data.children;
     this.genesis = data.genesis;
     this.creator = data.creator;
@@ -88,6 +90,7 @@ export async function getInscriptionFromEnvelope(
   return new Inscription({
     id: envelope.id,
     parent: envelope.parent,
+    delegate: envelope.delegate,
     children: [],
     genesis: envelope.txid,
     creator: await getInscriptionCreator(envelope.txid),
@@ -133,6 +136,7 @@ async function getInscriptionOwner(txid: string, n: number) {
 type InscriptionData = {
   id: string;
   parent?: string;
+  delegate?: string;
   children?: string[];
   genesis: string;
   creator: string;

--- a/src/Methods/Ordinals/GetInscriptions.ts
+++ b/src/Methods/Ordinals/GetInscriptions.ts
@@ -34,7 +34,7 @@ export default method({
       result.documents = await includeInscriptionValue(result.documents);
     }
     return {
-      inscriptions: result.documents,
+      inscriptions: await db.inscriptions.fillDelegateInscriptions(result.documents),
       pagination: result.pagination,
     };
   },

--- a/src/Methods/Ordinals/GetInscriptionsByIds.ts
+++ b/src/Methods/Ordinals/GetInscriptionsByIds.ts
@@ -9,12 +9,14 @@ export default method({
     ids: array.of(string),
   }),
   handler: async ({ ids }) => {
-    return db.inscriptions.find({ id: { $in: ids } }).then((inscriptions) => {
+    const inscriptions = await db.inscriptions.find({ id: { $in: ids } }).then((inscriptions) => {
       return inscriptions.map((inscription) => {
         delete (inscription as any)._id;
         inscription.mediaContent = `${config.api.uri}/content/${inscription.id}`;
         return inscription;
       });
     });
+
+    return db.inscriptions.fillDelegateInscriptions(inscriptions)
   },
 });

--- a/src/Methods/Ordinals/GetInscriptionsTransactions.ts
+++ b/src/Methods/Ordinals/GetInscriptionsTransactions.ts
@@ -1,12 +1,13 @@
 import { method } from "@valkyr/api";
 import Schema, { string } from "computed-types";
 
+import { limiter } from "~Libraries/Limiter";
+import { rpc } from "~Services/Bitcoin";
+
 import { config } from "../../Config";
 import { db } from "../../Database";
 import { schema } from "../../Libraries/Schema";
 import { getExpandedTransaction, parseLocation } from "../../Utilities/Transaction";
-import { rpc } from "~Services/Bitcoin";
-import { limiter } from "~Libraries/Limiter";
 
 export default method({
   params: Schema({
@@ -28,6 +29,7 @@ export default method({
     // get transactions
     const promiseLimiter = limiter<any>(10);
 
+    result.documents = await db.inscriptions.fillDelegateInscriptions(result.documents)
     result.documents.forEach((inscription) => {
       promiseLimiter.push(async () => {
         const [txid] = parseLocation(inscription.outpoint);

--- a/src/Services/Ord.ts
+++ b/src/Services/Ord.ts
@@ -194,6 +194,7 @@ export type InscriptionData = {
   inscription_sequence: number;
   output_value?: number;
   parent?: string;
+  delegate?: string;
   sat?: number;
   satpoint: string;
   timestamp: number;

--- a/src/Workers/Indexers/Inscriptions.ts
+++ b/src/Workers/Indexers/Inscriptions.ts
@@ -43,9 +43,13 @@ export const inscriptionsIndexer: IndexHandler = {
 async function getInscriptions(vins: VinData[]) {
   const envelopes: Envelope[] = [];
   for (const vin of vins) {
-    const envelope = Envelope.fromTxinWitness(vin.txid, vin.witness);
-    if (envelope && envelope.isValid) {
-      envelopes.push(envelope);
+    const _envelopes = Envelope.fromTxinWitness(vin.txid, vin.witness);
+    if (_envelopes) {
+      for (const envelope of _envelopes) {
+        if (envelope && envelope.isValid) {
+          envelopes.push(envelope);
+        }
+      }
     }
   }
 

--- a/src/Workers/Indexers/Inscriptions.ts
+++ b/src/Workers/Indexers/Inscriptions.ts
@@ -79,6 +79,7 @@ export async function insertInscriptions(rawInscriptions: RawInscription[]) {
   for (const inscription of rawInscriptions) {
     const entry: Partial<Inscription> = {
       id: inscription.id,
+      delegate: inscription.delegate,
       creator: inscription.creator,
       owner: inscription.owner,
       sat: inscription.sat,

--- a/src/Workers/Indexers/Inscriptions.ts
+++ b/src/Workers/Indexers/Inscriptions.ts
@@ -73,7 +73,7 @@ async function getInscriptions(vins: VinData[]) {
   return inscriptions;
 }
 
-async function insertInscriptions(rawInscriptions: RawInscription[]) {
+export async function insertInscriptions(rawInscriptions: RawInscription[]) {
   const inscriptions: Inscription[] = [];
 
   for (const inscription of rawInscriptions) {

--- a/src/Workers/Tasks/ReindexDelegateInscriptions.ts
+++ b/src/Workers/Tasks/ReindexDelegateInscriptions.ts
@@ -1,0 +1,47 @@
+import { db } from "~Database";
+import { log } from "~Libraries/Log";
+import { InscriptionData, ord } from "~Services/Ord";
+
+async function main() {
+  const total = await db.inscriptions.collection.estimatedDocumentCount();
+  log(`total inscriptions: ${total} \n`);
+
+  let count = 0;
+
+  const cursor = db.inscriptions.collection.find({}, { sort: { _id: -1 } });
+  while (await cursor.hasNext()) {
+    const inscription = await cursor.next();
+    if (inscription === null) {
+      continue;
+    }
+
+    log(`count: ${count}, inscription id: ${inscription.id} \n`);
+
+    if (!inscription.delegate) {
+      let ordData: InscriptionData | undefined;
+      try {
+        ordData = await ord.getInscription(inscription.id);
+      } catch (error) {
+        if (error?.message !== "Not found") {
+          log(error);
+        }
+      }
+      if (ordData) {
+        if (ordData.delegate) {
+          log(`found delegate inscription: ${ordData.delegate}, update inscription data: ${inscription.id} \n`);
+          await db.inscriptions.updateOne(
+            { _id: inscription._id },
+            {
+              $set: {
+                delegate: ordData.delegate,
+              },
+            },
+          );
+        }
+      }
+    }
+    count += 1;
+  }
+}
+
+main();

--- a/src/Workers/Tasks/ReindexInscriptionsPointers.ts
+++ b/src/Workers/Tasks/ReindexInscriptionsPointers.ts
@@ -58,7 +58,7 @@ async function main() {
     // try to reindex the transaction if the index 1 exist
     let ordData: InscriptionData | undefined;
     try {
-      ordData = await ord.getInscription(`${inscription.genesis}i1 \n`);
+      ordData = await ord.getInscription(`${inscription.genesis}i1`);
     } catch (error) {
       if (error?.message !== "Not found") {
         log(error);

--- a/src/Workers/Tasks/ReindexInscriptionsTx.ts
+++ b/src/Workers/Tasks/ReindexInscriptionsTx.ts
@@ -1,0 +1,75 @@
+import { db } from "~Database";
+import { Envelope } from "~Libraries/Inscriptions/Envelope";
+import { getInscriptionFromEnvelope, Inscription } from "~Libraries/Inscriptions/Inscription";
+import { log } from "~Libraries/Log";
+import { InscriptionData, ord, OrdInscription } from "~Services/Ord";
+
+import { rpc } from "../../Services/Bitcoin";
+import { insertInscriptions } from "../Indexers/Inscriptions";
+
+async function reIndexInscriptionsTx(txid: string) {
+  const rawTx = await rpc.transactions.getRawTransaction(txid, true);
+  const envelopes: Envelope[] = [];
+  const _envelopes = Envelope.fromTransaction(rawTx);
+  if (_envelopes) {
+    for (const envelope of _envelopes) {
+      if (envelope && envelope.isValid) {
+        envelopes.push(envelope);
+      }
+    }
+  }
+
+  const ordData = new Map<string, OrdInscription>();
+  const data = await ord.getInscriptionsForIds(envelopes.map((item) => item.id));
+  for (const item of data) {
+    ordData.set(item.inscription_id, item);
+  }
+
+  const inscriptions: Inscription[] = [];
+  for (const envelope of envelopes) {
+    const inscription = await getInscriptionFromEnvelope(envelope, ordData);
+    if (inscription !== undefined) {
+      inscriptions.push(inscription);
+    }
+  }
+
+  // skip the first index 0 inscription
+  inscriptions.shift();
+
+  await insertInscriptions(inscriptions);
+  log(`inserted inscriptions: ${JSON.stringify(inscriptions.map((v) => v.id))} \n`);
+}
+
+async function main() {
+  const total = await db.inscriptions.collection.estimatedDocumentCount();
+  log(`total inscriptions: ${total} \n`);
+
+  let count = 0;
+
+  const cursor = db.inscriptions.collection.find({}, { sort: { _id: -1 } });
+  while (await cursor.hasNext()) {
+    const inscription = await cursor.next();
+    if (inscription === null) {
+      continue;
+    }
+
+    log(`count: ${count}, inscription id: ${inscription.id} \n`);
+
+    // try to reindex the transaction if the index 1 exist
+    let ordData: InscriptionData | undefined;
+    try {
+      ordData = await ord.getInscription(`${inscription.genesis}i1 \n`);
+    } catch (error) {
+      if (error?.message !== "Not found") {
+        log(error);
+      }
+    }
+    if (ordData) {
+      log(`index 1 exist for inscription id: ${inscription.id}, try to reindex txid: ${inscription.genesis} \n`);
+      await reIndexInscriptionsTx(inscription.genesis);
+    }
+    count += 1;
+  }
+}
+
+main();


### PR DESCRIPTION
background: some witness transactions have more than one inscription (containing many inscriptions). currently, ordit only indexes the first inscription. this PR fixes the envelop function to parse multiple inscriptions in the witness transaction.

example tx: https://mempool.space/tx/c9f5ea06fbece058f66fb8171dff1c199a56f6f5f7e3007b7eb043def5c38a10