### PR TITLE
fix(script): skip duplicate txids for reindexing pointers

### DIFF
--- a/src/Workers/Tasks/ReindexInscriptionsPointers.ts
+++ b/src/Workers/Tasks/ReindexInscriptionsPointers.ts
@@ -45,6 +45,7 @@ async function main() {
   log(`total inscriptions: ${total} \n`);
 
   let count = 0;
+  const indexedSet = new Set<string>();
 
   const cursor = db.inscriptions.collection.find({}, { sort: { _id: -1 } });
   while (await cursor.hasNext()) {
@@ -54,6 +55,12 @@ async function main() {
     }
 
     log(`count: ${count}, inscription id: ${inscription.id} \n`);
+
+    if (indexedSet.has(inscription.genesis)) {
+      log(`txid already indexed: ${inscription.genesis}, skipping inscription \n`);
+      count += 1;
+      continue;
+    }
 
     // try to reindex the transaction if the index 1 exist
     let ordData: InscriptionData | undefined;
@@ -73,6 +80,7 @@ async function main() {
       }
     }
     count += 1;
+    indexedSet.add(inscription.genesis);
   }
 }
 


### PR DESCRIPTION
- Duplicate TXIDs might exist on DB, if multiple inscriptions from the same tx are already on database. This might be from partial indexing or script run.
- This skips indexing if non i0 inscriptions have been indexed already.