### PR TITLE
fix(api): fix mempool conflict issue

### DIFF
--- a/src/Methods/Address/GetSpendables.ts
+++ b/src/Methods/Address/GetSpendables.ts
@@ -56,11 +56,11 @@ export default method({
       }
 
       // ### Transaction
-      // We need to pull the raw transaction here to get the scriptPubKey.
-      // [TODO] We can potentially add this to the output index.
-
+      // We need to pull the transaction here to get the scriptPubKey.
+      // This also checks if the transaction has been spent or is in the mempool.
       const vout = await rpc.transactions.getTxOut(output.vout.txid, output.vout.n, true);
       if (vout === undefined) {
+        // if vout is undefined, then the output has been spent or is in the mempool (or is invalid for some reason)
         continue;
       }
 

--- a/src/Methods/Address/GetSpendables.ts
+++ b/src/Methods/Address/GetSpendables.ts
@@ -59,8 +59,8 @@ export default method({
       // We need to pull the raw transaction here to get the scriptPubKey.
       // [TODO] We can potentially add this to the output index.
 
-      const tx = await rpc.transactions.getRawTransaction(output.vout.txid, true);
-      if (tx === undefined) {
+      const vout = await rpc.transactions.getTxOut(output.vout.txid, output.vout.n, true);
+      if (vout === undefined) {
         continue;
       }
 
@@ -70,7 +70,7 @@ export default method({
         txid: output.vout.txid,
         n: output.vout.n,
         sats: btcToSat(output.value),
-        scriptPubKey: tx.vout[output.vout.n].scriptPubKey,
+        scriptPubKey: vout.scriptPubKey,
       });
 
       totalValue += output.value;

--- a/src/Methods/Address/GetUnspents.ts
+++ b/src/Methods/Address/GetUnspents.ts
@@ -64,12 +64,11 @@ export default method({
         }
       }
 
-      const tx = await rpc.transactions.getRawTransaction(output.vout.txid, true);
-      if (tx === undefined) {
+      const vout = await rpc.transactions.getTxOut(output.vout.txid, output.vout.n, true);
+      if (vout === undefined) {
         continue;
       }
 
-      const vout = tx.vout[output.vout.n];
       const utxo: any = {
         txid: output.vout.txid,
         n: output.vout.n,
@@ -78,6 +77,7 @@ export default method({
       };
 
       if (vout.scriptPubKey.type === "pubkeyhash") {
+        const tx = await rpc.transactions.getRawTransaction(output.vout.txid, true);
         utxo.txhex = tx.hex;
       }
 

--- a/src/Methods/Address/GetUnspents.ts
+++ b/src/Methods/Address/GetUnspents.ts
@@ -64,6 +64,9 @@ export default method({
         }
       }
 
+      // ### Transaction
+      // We need to pull the transaction here to get the scriptPubKey.
+      // This also checks if the transaction has been spent or is in the mempool.
       const vout = await rpc.transactions.getTxOut(output.vout.txid, output.vout.n, true);
       if (vout === undefined) {
         continue;
@@ -77,6 +80,7 @@ export default method({
       };
 
       if (vout.scriptPubKey.type === "pubkeyhash") {
+        // We need to pull the raw transaction here to get the scriptPubKey.
         const tx = await rpc.transactions.getRawTransaction(output.vout.txid, true);
         utxo.txhex = tx.hex;
       }

--- a/src/Services/Bitcoin/Transactions.ts
+++ b/src/Services/Bitcoin/Transactions.ts
@@ -10,6 +10,7 @@ export const transactions = {
     TRANSACTION_NOT_FOUND,
   },
   getRawTransaction,
+  getTxOut,
   decodeScript,
   sendRawTransaction,
   decodeRawTransaction,
@@ -44,6 +45,19 @@ async function getRawTransaction(txid: string, verbose?: false): Promise<string>
 async function getRawTransaction(txid: string, verbose: true): Promise<RawTransaction>;
 async function getRawTransaction(txid: string, verbose = false): Promise<RawTransaction | string> {
   return rpc<RawTransaction>("getrawtransaction", [txid, verbose]);
+}
+
+/**
+ * Get an unspent transaction output set by txid and index.
+ * If output is spent or does not exist, return null.
+ * If includeMempool is true, return null if output is in mempool.
+ *
+ * @param txid              - The transaction id.
+ * @param n                 - The transaction index.
+ * @param indcludeMempool   - Whether to include the mempool.
+ */
+async function getTxOut(txid: string, n: number, indcludeMempool: boolean = true): Promise<TxOut | undefined> {
+  return rpc("gettxout", [txid, n, indcludeMempool]);
 }
 
 /**
@@ -129,6 +143,14 @@ export type RawTransaction = {
   confirmations: number;
   blocktime: number;
   time: number;
+};
+
+export type TxOut = {
+  bestblock: string;
+  confirmations: number;
+  value: number;
+  scriptPubKey: ScriptPubKey;
+  coinbase: boolean;
 };
 
 export type DecodedTransaction = {


### PR DESCRIPTION
- Change `getrawtransaction` to `gettxout`, which excludes outputs already spent or waiting to be spent in the mempool