### PR TITLE
fix(indexer): track envelope index when parsing vins

### DIFF
--- a/src/Libraries/Inscriptions/Envelope.ts
+++ b/src/Libraries/Inscriptions/Envelope.ts
@@ -2,7 +2,6 @@ import { script } from "bitcoinjs-lib";
 
 import { isCoinbase, RawTransaction } from "../../Services/Bitcoin";
 import { getMetaFromWitness } from "./Oip";
-import { log } from "~Libraries/Log";
 
 const PROTOCOL_ID = "6f7264";
 
@@ -70,11 +69,9 @@ export class Envelope {
    */
   static fromTransaction(tx: RawTransaction) {
     const envelopes = getEnvelopesDataFromTx(tx);
-    log(`Found ${envelopes?.length} envelopes in tx: ${tx.txid}\n`);
     if (envelopes && envelopes.length > 0) {
       return envelopes.map(([data, oip], index) => {
         if (data) {
-          log(`Extracting envelope: ${tx.txid}i${index}\n`);
           return new Envelope(tx.txid, data, oip, index);
         }
         return undefined;
@@ -84,12 +81,10 @@ export class Envelope {
 
   static fromTxinWitness(txid: string, txinwitness: string[], currentEnelopeIndex: number) {
     const envelopes = getEnvelopesFromTxinWitness(txinwitness);
-    log(`Found ${envelopes?.length} envelopes in tx: ${txid}\n`);
     if (envelopes && envelopes.length > 0) {
       return envelopes.map(([data, oip], index) => {
         const envelopeIndex = index + currentEnelopeIndex;
         if (data) {
-          log(`Extracting envelope: ${txid}i${envelopeIndex}\n`);
           return new Envelope(txid, data, oip, envelopeIndex);
         }
         return undefined;
@@ -238,7 +233,6 @@ function getEnvelopesDataFromTx(tx: RawTransaction): [EnvelopeData[]?, any?][] |
     if (isCoinbase(vin)) {
       continue;
     }
-    log(`Extracting envelope from vin: ${vin.txid}i${vin.vout}\n`);
     if (vin.txinwitness) {
       const envelope = getEnvelopesFromTxinWitness(vin.txinwitness);
       if (envelope) {

--- a/src/Libraries/Inscriptions/Envelope.ts
+++ b/src/Libraries/Inscriptions/Envelope.ts
@@ -79,11 +79,11 @@ export class Envelope {
     }
   }
 
-  static fromTxinWitness(txid: string, txinwitness: string[], currentEnelopeIndex: number) {
+  static fromTxinWitness(txid: string, txinwitness: string[], currentEnvelopeIndex: number) {
     const envelopes = getEnvelopesFromTxinWitness(txinwitness);
     if (envelopes && envelopes.length > 0) {
       return envelopes.map(([data, oip], index) => {
-        const envelopeIndex = index + currentEnelopeIndex;
+        const envelopeIndex = index + currentEnvelopeIndex;
         if (data) {
           return new Envelope(txid, data, oip, envelopeIndex);
         }

--- a/src/Libraries/Inscriptions/Inscription.ts
+++ b/src/Libraries/Inscriptions/Inscription.ts
@@ -44,30 +44,6 @@ export class Inscription {
     this.meta = data.meta;
     this.oip = data.oip;
   }
-
-  static async fromTransaction(tx: RawTransaction) {
-    const envelopes = Envelope.fromTransaction(tx);
-    if (envelopes && envelopes.length > 0) {
-      return envelopes.map((envelope) => {
-        if (envelope?.isValid) {
-          return envelope;
-        }
-        return undefined;
-      });
-    }
-  }
-
-  static async fromVin(vin: VinData) {
-    const envelopes = Envelope.fromTxinWitness(vin.txid, vin.witness);
-    if (envelopes && envelopes.length > 0) {
-      return envelopes.map((envelope) => {
-        if (envelope?.isValid) {
-          return envelope;
-        }
-        return undefined;
-      });
-    }
-  }
 }
 
 /*

--- a/src/Workers/Indexers/Inscriptions.ts
+++ b/src/Workers/Indexers/Inscriptions.ts
@@ -43,20 +43,20 @@ export const inscriptionsIndexer: IndexHandler = {
 async function getInscriptions(vins: VinData[]) {
   const envelopes: Envelope[] = [];
   let currentTxid = "";
-  let currentEnelopeIndex = 0;
+  let currentEnvelopeIndex = 0;
   for (const vin of vins) {
     if (vin.txid !== currentTxid) {
       currentTxid = vin.txid;
-      currentEnelopeIndex = 0;
+      currentEnvelopeIndex = 0;
     }
-    const _envelopes = Envelope.fromTxinWitness(vin.txid, vin.witness, currentEnelopeIndex);
+    const _envelopes = Envelope.fromTxinWitness(vin.txid, vin.witness, currentEnvelopeIndex);
     if (_envelopes) {
       for (const envelope of _envelopes) {
         if (envelope && envelope.isValid) {
           envelopes.push(envelope);
         }
       }
-      currentEnelopeIndex += _envelopes.length;
+      currentEnvelopeIndex += _envelopes.length;
     }
   }
 

--- a/src/Workers/Indexers/Inscriptions.ts
+++ b/src/Workers/Indexers/Inscriptions.ts
@@ -42,14 +42,21 @@ export const inscriptionsIndexer: IndexHandler = {
 
 async function getInscriptions(vins: VinData[]) {
   const envelopes: Envelope[] = [];
+  let currentTxid = "";
+  let currentEnelopeIndex = 0;
   for (const vin of vins) {
-    const _envelopes = Envelope.fromTxinWitness(vin.txid, vin.witness);
+    if (vin.txid !== currentTxid) {
+      currentTxid = vin.txid;
+      currentEnelopeIndex = 0;
+    }
+    const _envelopes = Envelope.fromTxinWitness(vin.txid, vin.witness, currentEnelopeIndex);
     if (_envelopes) {
       for (const envelope of _envelopes) {
         if (envelope && envelope.isValid) {
           envelopes.push(envelope);
         }
       }
+      currentEnelopeIndex += _envelopes.length;
     }
   }
 


### PR DESCRIPTION
Fixes issue where the Indexer only indexes the first inscription (index 0) in a transaction