### PR TITLE
fix(api): txout returns null when utxo is spent in mempool

### DIFF
--- a/src/Methods/Address/GetSpendables.ts
+++ b/src/Methods/Address/GetSpendables.ts
@@ -59,8 +59,8 @@ export default method({
       // We need to pull the transaction here to get the scriptPubKey.
       // This also checks if the transaction has been spent or is in the mempool.
       const vout = await rpc.transactions.getTxOut(output.vout.txid, output.vout.n, true);
-      if (vout === undefined) {
-        // if vout is undefined, then the output has been spent or is in the mempool (or is invalid for some reason)
+      if (vout === null) {
+        // if vout is null, then the output has been spent or is in the mempool (or is invalid for some reason)
         continue;
       }
 

--- a/src/Methods/Address/GetUnspents.ts
+++ b/src/Methods/Address/GetUnspents.ts
@@ -68,7 +68,7 @@ export default method({
       // We need to pull the transaction here to get the scriptPubKey.
       // This also checks if the transaction has been spent or is in the mempool.
       const vout = await rpc.transactions.getTxOut(output.vout.txid, output.vout.n, true);
-      if (vout === undefined) {
+      if (vout === null) {
         continue;
       }
 

--- a/src/Services/Bitcoin/Transactions.ts
+++ b/src/Services/Bitcoin/Transactions.ts
@@ -56,7 +56,7 @@ async function getRawTransaction(txid: string, verbose = false): Promise<RawTran
  * @param n                 - The transaction index.
  * @param indcludeMempool   - Whether to include the mempool.
  */
-async function getTxOut(txid: string, n: number, indcludeMempool: boolean = true): Promise<TxOut | undefined> {
+async function getTxOut(txid: string, n: number, indcludeMempool: boolean = true): Promise<TxOut | null> {
   return rpc("gettxout", [txid, n, indcludeMempool]);
 }
 


### PR DESCRIPTION
- When UTXO is spent in mempool, the [`gettxout`](https://bitcoincore.org/en/doc/27.0.0/rpc/blockchain/gettxout/) RPC method returns `null` instead of `undefined`.