### PR TITLE
feat(indexer): add config setting for maxheight

### DIFF
--- a/dotenv
+++ b/dotenv
@@ -44,6 +44,7 @@ INDEX_UTXOS=true
 INDEX_INSCRIPTIONS=true
 INDEX_BRC20=true
 INDEX_SADO=true
+# MAXHEIGHT=767430
 
 # ORD SERVER
 # Currently used to serve our ability to track sat ranges and

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -20,6 +20,7 @@ export const config = {
     inscriptions: getEnvironmentVariable("INDEX_INSCRIPTIONS", envToBoolean),
     brc20: getEnvironmentVariable("INDEX_BRC20", envToBoolean),
     sado: getEnvironmentVariable("INDEX_SADO", envToBoolean),
+    maxheight: getEnvironmentVariable("MAXHEIGHT", envToNumber, true),
   },
   ord: {
     uri: getEnvironmentVariable("ORD_URI"),

--- a/src/Workers/Index.ts
+++ b/src/Workers/Index.ts
@@ -32,7 +32,7 @@ export async function index() {
     indexers.push(sadoIndexer);
   }
 
-  if (config.index.maxheight && config.index.maxheight >= blockHeight) {
+  if (config.index.maxheight && blockHeight >= config.index.maxheight) {
     log(`Already at maxheight ${blockHeight}`);
     return blockHeight;
   }

--- a/src/Workers/Index.ts
+++ b/src/Workers/Index.ts
@@ -1,5 +1,6 @@
 import { config } from "~Config";
 import { Indexer, IndexHandler } from "~Libraries/Indexer";
+import { log } from "~Libraries/Log";
 import { rpc } from "~Services/Bitcoin";
 
 import { brc20Indexer } from "./Indexers/Brc20";
@@ -29,6 +30,11 @@ export async function index() {
 
   if (config.index.sado === true) {
     indexers.push(sadoIndexer);
+  }
+
+  if (config.index.maxheight && config.index.maxheight >= blockHeight) {
+    log(`Already at maxheight ${blockHeight}`);
+    return blockHeight;
   }
 
   const indexer = new Indexer({ indexers });

--- a/src/Workers/Worker.ts
+++ b/src/Workers/Worker.ts
@@ -137,6 +137,10 @@ function getWorkerStatus() {
 const start = async () => {
   await bootstrap();
   lastHeight = await db.outputs.getHeighestBlock();
+  if (config.index.maxheight && config.index.maxheight >= lastHeight) {
+    console.log(`Already at maxheight ${lastHeight}`);
+    return;
+  }
   await fastify
     .listen({ host: config.worker.host, port: config.worker.port })
     .then((address) => {

--- a/src/Workers/Worker.ts
+++ b/src/Workers/Worker.ts
@@ -137,7 +137,7 @@ function getWorkerStatus() {
 const start = async () => {
   await bootstrap();
   lastHeight = await db.outputs.getHeighestBlock();
-  if (config.index.maxheight && config.index.maxheight >= lastHeight) {
+  if (config.index.maxheight && lastHeight >= config.index.maxheight) {
     console.log(`Already at maxheight ${lastHeight}`);
     return;
   }


### PR DESCRIPTION
Allow for an optional `maxheight` setting to stop indexing at `maxheight`. This would make it easier to take DB snapshots at specific heights (eg. before first inscription height, before jubilee height, etc.).