### PR TITLE
fix(indexer): optional configs not returning undefined when not set

### DIFF
--- a/src/Libraries/Environment.ts
+++ b/src/Libraries/Environment.ts
@@ -19,6 +19,9 @@ export function getEnvironmentVariable<T extends EnvParser>(key: string, parse?:
   if (value === undefined && optional !== true) {
     throw new Error(`Config Exception: Missing ${key} variable in configuration`);
   }
+  if (value === undefined && optional === true) {
+    return undefined as any;
+  }
   return parse ? parse(value) : envToString(value);
 }
 


### PR DESCRIPTION
- Configs can be optional, but setting `optional` as `true` but not setting the variable on `.env` throws an error
- This fix returns `undefined` when an optional config is not set