### PR TITLE
feat(api): Runes.GetSpendableIndex endpoint

### DIFF
--- a/src/Database/Output/Collection.ts
+++ b/src/Database/Output/Collection.ts
@@ -1,3 +1,4 @@
+import { ScriptPubKey } from "~Services/Bitcoin";
 import { CollectionRegistrar, mongo } from "../../Services/Mongo";
 
 export const collection = mongo.db.collection<OutputDocument>("outputs");
@@ -45,6 +46,7 @@ export type OutputDocument = {
   vout: OutputTransaction;
   vin?: OutputTransaction;
   spent?: true;
+  scriptPubKey: ScriptPubKey | Buffer;
 };
 
 export type SpentOutput = {

--- a/src/Libraries/Runes/types.ts
+++ b/src/Libraries/Runes/types.ts
@@ -4,7 +4,7 @@ export type UTXO = {
   txid: string;
   n: number;
   sats: number;
-  scriptPubKey: ScriptPubKey;
+  scriptPubKey: ScriptPubKey | Buffer;
 };
 
 export type Outpoint = {

--- a/src/Methods/Runes/GetSpendablesIndex.ts
+++ b/src/Methods/Runes/GetSpendablesIndex.ts
@@ -1,0 +1,55 @@
+import { method } from "@valkyr/api";
+import Schema, { string } from "computed-types";
+
+import { inscriptions } from "~Database/Inscriptions";
+import { noSpentsFilter } from "~Database/Output/Utilities";
+import { runes } from "~Database/Runes";
+import { UTXO } from "~Libraries/Runes/types";
+
+import { db } from "../../Database";
+
+export default method({
+  params: Schema({
+    address: string,
+  }),
+  handler: async ({ address }) => {
+    const outputs = await db.outputs.find({ addresses: address, ...noSpentsFilter });
+    if (!outputs) {
+      return [];
+    }
+
+    const allOutputs: UTXO[] = outputs.map(
+      (runeOut): UTXO => ({
+        txid: runeOut.vout.txid,
+        n: runeOut.vout.n,
+        sats: runeOut.value,
+        scriptPubKey: runeOut.scriptPubKey,
+      }),
+    );
+
+    const runesOutputs = await runes.addressBalances(address);
+
+    let runesUTXOs: UTXO[] = [];
+    if (runesOutputs) {
+      runesUTXOs = runesOutputs.map(
+        (runeOut): UTXO => ({
+          txid: runeOut.txid,
+          n: runeOut.vout,
+          sats: runeOut.satValue,
+          scriptPubKey: runeOut.scriptPubKey,
+        }),
+      );
+    }
+
+    const result = await Promise.all(
+      allOutputs.map(async (output) => {
+        const hasInscriptions = await inscriptions.hasInscriptions(output.txid, output.n);
+        const isInRunesUTXOs = runesUTXOs.some((runeOut) => runeOut.txid === output.txid && runeOut.n === output.n);
+        return !isInRunesUTXOs && !hasInscriptions;
+      }),
+    );
+
+    const filteredResults = allOutputs.filter((_, index) => result[index]);
+    return filteredResults;
+  },
+});

--- a/src/Workers/Indexers/Outputs.ts
+++ b/src/Workers/Indexers/Outputs.ts
@@ -24,6 +24,7 @@ export const outputIndexer: IndexHandler = {
           txid: vout.txid,
           n: vout.n,
         },
+        scriptPubKey: vout.scriptPubKey,
       });
     }
 


### PR DESCRIPTION
Implementation of Runes.GetSpendableIndex endpoint which returns all utxos that are safe to spend, meaning they contain no rune balances or inscriptions