### PR TITLE
fix(api): turn off X-Content-Type-Options on header for fastify helmet

### DIFF
--- a/src/Fastify.ts
+++ b/src/Fastify.ts
@@ -5,10 +5,12 @@ import Fastify from "fastify";
 import { api } from "./Api";
 
 export const fastify = Fastify();
-fastify.addHook('onRequest', async (request, reply) => {
-    reply.header('Cross-Origin-Resource-Policy', 'cross-origin');
+fastify.addHook("onRequest", async (request, reply) => {
+  reply.header("Cross-Origin-Resource-Policy", "cross-origin");
 });
 
 fastify.register(cors);
-fastify.register(helmet);
+fastify.register(helmet, {
+  xContentTypeOptions: false,
+});
 fastify.register(api.fastify);


### PR DESCRIPTION
- Removes `X-Content-Type-Options: nosniff` from header to better support recursive inscriptions