### PR TITLE
fix(api): add parameter to make cursor information optional on pagination

### DIFF
--- a/src/Libraries/Paginate/FindPaginated.ts
+++ b/src/Libraries/Paginate/FindPaginated.ts
@@ -51,7 +51,7 @@ export const findPaginated = async <T extends Document>(
   const firstDocumentCursor = encodeCursor(buildCursor(documents[0], sort));
   const lastDocumentCursor = encodeCursor(buildCursor(documents[documents.length - 1], sort));
 
-  // Only add $cursor to the document if verbose is true
+  // Only add $cursor to the document if cursorInfo is true
   for (const document of documents) {
     if (cursorInfo) {
       document.$cursor = encodeCursor(buildCursor(document, sort));

--- a/src/Methods/Runes/GetAddressRuneUTXOIndex.ts
+++ b/src/Methods/Runes/GetAddressRuneUTXOIndex.ts
@@ -21,6 +21,7 @@ export default method({
       ...pagination,
       filter: { address, runeTicker },
       sort,
+      cursorInfo: false,
     };
     const balances = await runes.addressRunesUTXOs(params);
 


### PR DESCRIPTION
- Added a cursorInfo flag to the findPaginated function (default true)
- $cursor is now omited from the individual documents only when cursorInfo is set to false.
- Cursors for prev and next pagination fields are always computed and returned, regardless of cursorInfo flag.