### PR TITLE
feat(indexer) add blockConcurrencyLimit

### DIFF
--- a/dotenv
+++ b/dotenv
@@ -51,9 +51,10 @@ INDEX_RUNES=true
 # INDEXER SETTINGS
 #------------------------------------------------------------
 INDEXER_MAX_HEIGHT=767430
-INDEXER_COMMIT_BLOCKS=1000
+INDEXER_COMMIT_BLOCKS=1000 # Set the limit at which blocks are concurrently processed.
 INDEXER_DB_CHUNK_SIZE=1000 # Chunks of data for i/o ops against db. Keep between 1_000 - 10_000.
 INDEXER_VOUT_CONCURRENCY_LIMIT=100 # Set the limit at which vouts are concurrently processed.
+INDEXER_BLOCK_CONCURRENCY_LIMIT=8 # Set the limit at which blocks are concurrently fetched using getBlock RPC.
 
 
 # ORD SERVER

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -25,6 +25,7 @@ export const config = {
     blocksThreshold: getEnvironmentVariable("INDEXER_COMMIT_BLOCKS", envToNumber, true),
     chunkSize: getEnvironmentVariable("INDEXER_DB_CHUNK_SIZE", envToNumber, true),
     voutConcurrencyLimit: getEnvironmentVariable("INDEXER_VOUT_CONCURRENCY_LIMIT", envToNumber, true),
+    blockConcurrencyLimit: getEnvironmentVariable("INDEXER_BLOCK_CONCURRENCY_LIMIT", envToNumber, true),
   },
   ord: {
     uri: getEnvironmentVariable("ORD_URI"),


### PR DESCRIPTION
Adds INDEXER_BLOCK_CONCURRENCY_LIMIT. 
This variable will set the limit at which blocks are concurrently fetched by getBlock RPC.