### PR TITLE
fix(api): make runeTicker optional and add includeSpent param

### DIFF
--- a/src/Methods/Runes/GetAddressRuneUTXOIndex.ts
+++ b/src/Methods/Runes/GetAddressRuneUTXOIndex.ts
@@ -1,5 +1,6 @@
 import { method } from "@valkyr/api";
-import Schema, { string } from "computed-types";
+import Schema, { boolean, string } from "computed-types";
+import { Filter } from "mongodb";
 import { RuneUtxoBalance } from "runestone-lib";
 
 import { runes } from "~Database/Runes";
@@ -10,16 +11,25 @@ import { schema } from "../../Libraries/Schema";
 export default method({
   params: Schema({
     address: string,
-    runeTicker: string,
+    runeTicker: string.optional(),
     pagination: schema.pagination.optional(),
     sort: schema.sort,
+    includeSpent: boolean.optional(),
   }),
-  handler: async ({ address, runeTicker, pagination = {}, sort }) => {
+  handler: async ({ address, runeTicker, pagination = {}, sort, includeSpent = false }) => {
     pagination.limit ??= 50;
     sort ??= { _id: "asc" };
+
+    const filter: Filter<RuneUtxoBalance> = { address };
+    if (runeTicker) {
+      filter.runeTicker = runeTicker;
+    }
+    if (!includeSpent) {
+      filter.spentTxid = { $exists: false };
+    }
     const params: FindPaginatedParams<RuneUtxoBalance> = {
       ...pagination,
-      filter: { address, runeTicker },
+      filter,
       sort,
       cursorInfo: false,
     };


### PR DESCRIPTION
Runes.GetAddressRuneUTXOIndex:

- Make runeTicker optional to be able to retrieve all UTXOs with runes and balances of an address
- Added includeSpent optional param to be able to retrieve spent UTXOs conditionally. Defaults to false.