### PR TITLE
feat(api): add pagination to Address.GetSpendables

### DIFF
--- a/src/Database/Output/Methods.ts
+++ b/src/Database/Output/Methods.ts
@@ -10,6 +10,7 @@ import {
 } from "mongodb";
 
 import { ignoreDuplicateErrors } from "~Database/Utilities";
+import { FindPaginatedParams, paginate } from "~Libraries/Paginate";
 
 import { getChunkSize } from "../Utilities";
 import { collection, deployedCollection, OutputDocument, SpentOutput } from "./Collection";
@@ -24,6 +25,7 @@ export const outputs = {
   insertMany,
   find,
   findOne,
+  findPaginated,
   updateOne,
   cursor,
   aggregate,
@@ -67,6 +69,10 @@ async function insertMany(outputs: OutputDocument[]) {
 
 async function find(filter: Filter<OutputDocument>, options?: FindOptions<OutputDocument>) {
   return collection.find(filter, options).toArray();
+}
+
+async function findPaginated(params: FindPaginatedParams<OutputDocument> = {}) {
+  return paginate.findPaginated(collection, params);
 }
 
 async function findOne(

--- a/src/Methods/Address/GetSpendables.ts
+++ b/src/Methods/Address/GetSpendables.ts
@@ -1,15 +1,17 @@
 import { BadRequestError, method } from "@valkyr/api";
 import Schema, { array, boolean, number, string } from "computed-types";
 
+import { OutputDocument } from "~Database/Output";
+import { FindPaginatedParams } from "~Libraries/Paginate";
+import { SortDirection } from "~Libraries/Paginate/Types";
+import { pagination } from "~Utilities/Pagination";
 import { outputHasRunes } from "~Utilities/Runes";
 
 import { db } from "../../Database";
 import { noSpentsFilter } from "../../Database/Output/Utilities";
-import { rpc } from "../../Services/Bitcoin";
+import { rpc, ScriptPubKey } from "../../Services/Bitcoin";
 import { getSafeToSpendState, ord } from "../../Services/Ord";
 import { btcToSat } from "../../Utilities/Bitcoin";
-
-const MAX_SPENDABLES = 200;
 
 export default method({
   params: Schema({
@@ -17,22 +19,29 @@ export default method({
     value: number.optional(),
     safetospend: boolean.optional(),
     filter: array.of(string).optional(),
-    limit: number.optional(),
+    pagination: pagination.optional(),
   }),
-  handler: async ({ address, value, safetospend = true, filter = [], limit }) => {
-    const spendables = [];
+  handler: async ({ address, value, safetospend = true, filter = [], pagination = {} }) => {
+    const spendables: { txid: string; n: number; sats: number; scriptPubKey: ScriptPubKey }[] = [];
 
     let totalValue = 0;
     let safeToSpend = 0;
     let scanned = 0;
 
-    const cursor = db.outputs.collection.find({ addresses: address, ...noSpentsFilter }, { sort: { value: -1 } });
+    pagination.limit ??= 100;
+    const paginationFilter = { addresses: address, ...noSpentsFilter };
+    const sort = { _id: "asc" as SortDirection };
 
-    while (await cursor.hasNext()) {
-      const output = await cursor.next();
-      if (output === null) {
-        continue;
-      }
+    const paginationParam: FindPaginatedParams<OutputDocument> = {
+      ...pagination,
+      filter: paginationFilter,
+      sort,
+    };
+    const outputs = await db.outputs.findPaginated(paginationParam);
+
+    if (outputs.documents.length === 0) return { spendables, pagination: outputs.pagination };
+
+    for (const output of outputs.documents) {
       scanned += 1;
 
       const outpoint = `${output.vout.txid}:${output.vout.n}`;
@@ -80,9 +89,6 @@ export default method({
       if (value && totalValue >= value) {
         break;
       }
-      if (spendables.length >= (limit ?? MAX_SPENDABLES)) {
-        break;
-      }
     }
 
     if (value && totalValue < value) {
@@ -96,6 +102,6 @@ export default method({
       });
     }
 
-    return spendables;
+    return { spendables, pagination: outputs.pagination };
   },
 });


### PR DESCRIPTION
This PR introduces pagination to Address.GetSpendable

Note: This will break ordit-sdk since the response now is { spendables: [], pagination: {} }