### PR TITLE
fix(indexer): better reorg handling

### DIFF
--- a/dotenv
+++ b/dotenv
@@ -53,6 +53,7 @@ INDEX_UTXOS=true
 # INDEXER SETTINGS
 #------------------------------------------------------------
 INDEXER_MAX_HEIGHT=767430
+INDEXER_START_HEIGHT=188700 # Set the start height to index from
 INDEXER_COMMIT_BLOCKS=1000 # Set the limit at which blocks are concurrently processed.
 INDEXER_DB_CHUNK_SIZE=1000 # Chunks of data for i/o ops against db. Keep between 1_000 - 10_000.
 INDEXER_VOUT_CONCURRENCY_LIMIT=100 # Set the limit at which vouts are concurrently processed.

--- a/dotenv
+++ b/dotenv
@@ -41,11 +41,13 @@ WORKER_PORT=3031
 # INDEXER OPTIONS
 #------------------------------------------------------------
 INDEX_OUTPUTS=true
-INDEX_UTXOS=true
-INDEX_INSCRIPTIONS=true
+INDEX_INSCRIPTIONS=true # dependant on INDEX_OUTPUTS=true
+INDEX_RUNES=true # dependant on INDEX_OUTPUTS=true
+INDEX_RUNES_ONLY=false # Optional, if set to true only runes will be indexed skiping outputs
+# Deprecated
 INDEX_BRC20=true
 INDEX_SADO=true
-INDEX_RUNES=true
+INDEX_UTXOS=true
 
 #------------------------------------------------------------
 # INDEXER SETTINGS

--- a/indexer_runner.sh
+++ b/indexer_runner.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Script Name: run_indexer.sh
+# Description: This script launches the command "INDEXER_COMMIT_BLOCKS=<value> npm run indexer".
+# It automatically detects the total RAM of the machine and sets the Node.js memory option (--max-old-space-size)
+# to 90% of that capacity. If the command runs for more than 2 minutes with COMMIT_BLOCKS < 5000, the script
+# will terminate and restart it with MAX_COMMIT_BLOCKS and resume decreasing if it fails.
+# Parameters:
+#   1. MAX_COMMIT_BLOCKS (optional): The initial value for INDEXER_COMMIT_BLOCKS. Default is 5000.
+#   2. MIN_COMMIT_BLOCKS (optional): The minimum value for INDEXER_COMMIT_BLOCKS before giving up. Default is 10.
+
+# Function to detect total system RAM in MB and set Node.js memory limit to 90% of it
+set_memory_limit() {
+    total_ram_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+    total_ram_mb=$((total_ram_kb / 1024))
+    max_memory_mb=$((total_ram_mb * 90 / 100)) # 90% of total RAM in MB
+    echo "Detected total RAM: ${total_ram_mb} MB. Setting Node.js memory limit to ${max_memory_mb} MB."
+    export NODE_OPTIONS="--max-old-space-size=${max_memory_mb}"
+}
+
+MAX_COMMIT_BLOCKS=${1:-5000}
+MIN_COMMIT_BLOCKS=${2:-10}
+
+COMMIT_BLOCKS=$MAX_COMMIT_BLOCKS
+
+# Calculate the decrement value based on the number of digits in MAX_COMMIT_BLOCKS
+DECREASE_INTERVAL=$((10 ** (${#MAX_COMMIT_BLOCKS} - 1)))
+
+# Create a temporary file to capture command output
+LOG_FILE=$(mktemp)
+
+set_memory_limit
+
+run_command() {
+    # Clear the log file before running the command
+    >"$LOG_FILE"
+
+    # Run the command in the background and get its PID
+    INDEXER_COMMIT_BLOCKS=$COMMIT_BLOCKS npm run indexer 2>&1 | tee "$LOG_FILE" &
+    command_pid=$!
+
+    # Monitor the command for 10 minutes
+    runtime=0
+    while [ $runtime -lt 600 ]; do
+        # Check if the command is still running
+        if ! ps -p $command_pid >/dev/null; then
+            break
+        fi
+
+        # Check the log file for the "JavaScript heap out of memory" error in real-time
+        if grep -q "JavaScript heap out of memory" "$LOG_FILE"; then
+            echo "Detected 'JavaScript heap out of memory' error. Terminating the command..."
+            kill -9 $command_pid
+            wait $command_pid 2>/dev/null
+            return 1
+        fi
+
+        sleep 1
+        runtime=$((runtime + 1))
+    done
+
+    # If the command is still running after 10 minutes and COMMIT_BLOCKS < 5000, terminate and restart to set higher MAX_COMMIT_BLOCKS
+    if ps -p $command_pid >/dev/null && [ $COMMIT_BLOCKS -lt 5000 ]; then
+        echo "Command is still running after 2 minutes with COMMIT_BLOCKS=$COMMIT_BLOCKS. Restarting with MAX_COMMIT_BLOCKS=$MAX_COMMIT_BLOCKS."
+        kill -9 $command_pid
+        wait $command_pid 2>/dev/null
+        COMMIT_BLOCKS=$MAX_COMMIT_BLOCKS
+        return 2 # Indicate restart with max value
+    fi
+
+    # Wait for the command to finish and capture its exit status
+    wait $command_pid
+    command_exit_status=$?
+    if [ $command_exit_status -ne 0 ]; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+# Loop until the command succeeds or the value of COMMIT_BLOCKS is too low
+while [ $COMMIT_BLOCKS -ge $MIN_COMMIT_BLOCKS ]; do
+    echo "Running with INDEXER_COMMIT_BLOCKS=$COMMIT_BLOCKS"
+
+    run_command
+    case $? in
+    0)
+        echo "Command succeeded with INDEXER_COMMIT_BLOCKS=$COMMIT_BLOCKS"
+        rm "$LOG_FILE" # Remove the temporary log file
+        exit 0
+        ;;
+    1)
+        echo "Command failed or ran out of memory with INDEXER_COMMIT_BLOCKS=$COMMIT_BLOCKS"
+        if ((COMMIT_BLOCKS - DECREASE_INTERVAL < MIN_COMMIT_BLOCKS)); then
+            COMMIT_BLOCKS=$MIN_COMMIT_BLOCKS
+        else
+            COMMIT_BLOCKS=$((COMMIT_BLOCKS - DECREASE_INTERVAL))
+        fi
+        ;;
+    2)
+        echo "Restarting command with MAX_COMMIT_BLOCKS=$MAX_COMMIT_BLOCKS due to prolonged runtime."
+        COMMIT_BLOCKS=$MAX_COMMIT_BLOCKS
+        ;;
+    esac
+done
+
+echo "Command failed with all values. Minimum threshold reached."
+rm "$LOG_FILE" # Remove the temporary log file
+exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "mongodb": "^6.5.0",
         "node-fetch": "^3.3.2",
         "p-limit": "^4.0.0",
-        "runestone-lib": "git+https://github.com/me-foundation/runestone-lib.git",
+        "runestone-lib": "git+https://github.com/ordzaar/runestone-lib.git",
         "tiny-secp256k1": "^2.2.3"
       },
       "devDependencies": {
@@ -4380,7 +4380,7 @@
     "node_modules/runestone-lib": {
       "name": "@magiceden-oss/runestone-lib",
       "version": "1.0.2",
-      "resolved": "git+ssh://git@github.com/me-foundation/runestone-lib.git#13b5ef995f44e881b6de541a2f7d5cf77ad491e9",
+      "resolved": "git+ssh://git@github.com/ordzaar/runestone-lib.git#226f08350e39819344a920d53e79cb0f070a441a",
       "license": "ISC"
     },
     "node_modules/safe-buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4380,7 +4380,8 @@
     "node_modules/runestone-lib": {
       "name": "@magiceden-oss/runestone-lib",
       "version": "1.0.2",
-      "resolved": "git+ssh://git@github.com/ordzaar/runestone-lib.git#226f08350e39819344a920d53e79cb0f070a441a",
+      "resolved": "git+ssh://git@github.com/ordzaar/runestone-lib.git#6c1d860f7d732c3b300ef2bb23198321f4301cc5",
+      "integrity": "sha512-azlbtNRsjohfCxGSiHMtuSwnU6GdJXAjtojkzKUihGn43huEQtG3D4FELSkoxuFanKSrjNDiyH3DZFk2Yanc0g==",
       "license": "ISC"
     },
     "node_modules/safe-buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "computed-types": "^1.11.2",
         "dotenv": "^16.3.1",
         "fastify": "^4.26.2",
+        "flatted": "^3.3.1",
         "form-data": "^4.0.0",
         "ioredis": "^5.3.2",
         "lodash.get": "^4.4.2",
@@ -28,7 +29,7 @@
         "mongodb": "^6.5.0",
         "node-fetch": "^3.3.2",
         "p-limit": "^4.0.0",
-        "runestone-lib": "git+https://github.com/ordzaar/runestone-lib.git",
+        "runestone-lib": "git+https://github.com/me-foundation/runestone-lib.git",
         "tiny-secp256k1": "^2.2.3"
       },
       "devDependencies": {
@@ -2636,8 +2637,7 @@
     "node_modules/flatted": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
     },
     "node_modules/form-data": {
       "version": "4.0.0",
@@ -4380,7 +4380,7 @@
     "node_modules/runestone-lib": {
       "name": "@magiceden-oss/runestone-lib",
       "version": "1.0.2",
-      "resolved": "git+ssh://git@github.com/ordzaar/runestone-lib.git#6c1d860f7d732c3b300ef2bb23198321f4301cc5",
+      "resolved": "git+ssh://git@github.com/me-foundation/runestone-lib.git#13b5ef995f44e881b6de541a2f7d5cf77ad491e9",
       "license": "ISC"
     },
     "node_modules/safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mongodb": "^6.5.0",
     "node-fetch": "^3.3.2",
     "p-limit": "^4.0.0",
-    "runestone-lib": "git+https://github.com/me-foundation/runestone-lib.git",
+    "runestone-lib": "git+https://github.com/ordzaar/runestone-lib.git",
     "tiny-secp256k1": "^2.2.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "computed-types": "^1.11.2",
     "dotenv": "^16.3.1",
     "fastify": "^4.26.2",
+    "flatted": "^3.3.1",
     "form-data": "^4.0.0",
     "ioredis": "^5.3.2",
     "lodash.get": "^4.4.2",
@@ -38,7 +39,7 @@
     "mongodb": "^6.5.0",
     "node-fetch": "^3.3.2",
     "p-limit": "^4.0.0",
-    "runestone-lib": "git+https://github.com/ordzaar/runestone-lib.git",
+    "runestone-lib": "git+https://github.com/me-foundation/runestone-lib.git",
     "tiny-secp256k1": "^2.2.3"
   },
   "devDependencies": {

--- a/src/Bootstrap.ts
+++ b/src/Bootstrap.ts
@@ -8,6 +8,7 @@ import { registrar as ipfs } from "./Database/IPFS/Collection";
 import { registrar as media } from "./Database/Media/Collection";
 import { registrar as output } from "./Database/Output/Collection";
 import { registrarBlockInfo as runesBlockInfo } from "./Database/Runes/Collection";
+import { registrarEtching as runesEtching } from "./Database/Runes/Collection";
 import { registrarOutput as runesOutput } from "./Database/Runes/Collection";
 import { registrar as sadoEvents } from "./Database/Sado/Events/Collection";
 import { registrar as sadoOrders } from "./Database/Sado/Orders/Collection";
@@ -31,6 +32,7 @@ async function database() {
     media,
     output,
     runesBlockInfo,
+    runesEtching,
     runesOutput,
     sadoEvents,
     sadoOrders,

--- a/src/Bootstrap.ts
+++ b/src/Bootstrap.ts
@@ -7,9 +7,8 @@ import { registrar as inscriptions } from "./Database/Inscriptions/Collection";
 import { registrar as ipfs } from "./Database/IPFS/Collection";
 import { registrar as media } from "./Database/Media/Collection";
 import { registrar as output } from "./Database/Output/Collection";
-import { registrarBlocks as runesBlocks } from "./Database/Runes/Collection";
-import { registrarRunes as runes } from "./Database/Runes/Collection";
-import { registrarUtxoBalance as runesUtxoBalances } from "./Database/Runes/Collection";
+import { registrarBlockInfo as runesBlockInfo } from "./Database/Runes/Collection";
+import { registrarOutput as runesOutput } from "./Database/Runes/Collection";
 import { registrar as sadoEvents } from "./Database/Sado/Events/Collection";
 import { registrar as sadoOrders } from "./Database/Sado/Orders/Collection";
 import { registrar as utxos } from "./Database/Utxos/Collection";
@@ -31,9 +30,8 @@ async function database() {
     ipfs,
     media,
     output,
-    runes,
-    runesBlocks,
-    runesUtxoBalances,
+    runesBlockInfo,
+    runesOutput,
     sadoEvents,
     sadoOrders,
     utxos,

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -23,6 +23,7 @@ export const config = {
     runes: getEnvironmentVariable("INDEX_RUNES", envToBoolean),
     runesOnly: getEnvironmentVariable("INDEX_RUNES_ONLY", envToBoolean, true),
     maxheight: getEnvironmentVariable("INDEXER_MAX_HEIGHT", envToNumber, true),
+    startHeight: getEnvironmentVariable("INDEXER_START_HEIGHT", envToNumber, true),
     blocksThreshold: getEnvironmentVariable("INDEXER_COMMIT_BLOCKS", envToNumber, true),
     chunkSize: getEnvironmentVariable("INDEXER_DB_CHUNK_SIZE", envToNumber, true),
     voutConcurrencyLimit: getEnvironmentVariable("INDEXER_VOUT_CONCURRENCY_LIMIT", envToNumber, true),

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -21,6 +21,7 @@ export const config = {
     brc20: getEnvironmentVariable("INDEX_BRC20", envToBoolean),
     sado: getEnvironmentVariable("INDEX_SADO", envToBoolean),
     runes: getEnvironmentVariable("INDEX_RUNES", envToBoolean),
+    runesOnly: getEnvironmentVariable("INDEX_RUNES_ONLY", envToBoolean, true),
     maxheight: getEnvironmentVariable("INDEXER_MAX_HEIGHT", envToNumber, true),
     blocksThreshold: getEnvironmentVariable("INDEXER_COMMIT_BLOCKS", envToNumber, true),
     chunkSize: getEnvironmentVariable("INDEXER_DB_CHUNK_SIZE", envToNumber, true),

--- a/src/Database/Runes/Collection.ts
+++ b/src/Database/Runes/Collection.ts
@@ -27,4 +27,4 @@ export const registrarOutput: CollectionRegistrar = {
 };
 
 export type RuneOutput = RuneUtxoBalance & { txBlockHeight: number; spentTxid?: string }; // txBlockHeight needed for reorg
-export type SimplifiedRuneBlockIndex = Omit<RuneBlockIndex, "utxoBalances" | "spentBalances" | "reorg">;
+export type SimplifiedRuneBlockIndex = Omit<RuneBlockIndex, "etchings" | "utxoBalances" | "spentBalances" | "reorg">;

--- a/src/Database/Runes/Collection.ts
+++ b/src/Database/Runes/Collection.ts
@@ -1,18 +1,17 @@
-import { BlockInfo, RuneBalance, RuneEtching, RuneUtxoBalance } from "runestone-lib";
+import { RuneBlockIndex, RuneUtxoBalance } from "runestone-lib";
 
 import { CollectionRegistrar, mongo } from "~Services/Mongo";
 
-export const collectionBlocks = mongo.db.collection<BlockInfo>("runes_blocks");
-export const collectionUtxoBalances = mongo.db.collection<RuneUtxoBalance>("runes_utxoBalances");
-export const collectionRunes = mongo.db.collection<RuneEntry>("runes");
+export const collectionBlockInfo = mongo.db.collection<SimplifiedRuneBlockIndex>("runes_blocks");
+export const collectionOutputs = mongo.db.collection<RuneOutput>("runes_outputs");
 
-export const registrarBlocks: CollectionRegistrar = {
+export const registrarBlockInfo: CollectionRegistrar = {
   name: "runes_blocks",
-  indexes: [[{ height: 1 }, { unique: true }]],
+  indexes: [[{ "block.height": 1 }, { unique: true }]],
 };
 
-export const registrarUtxoBalance: CollectionRegistrar = {
-  name: "runes_utxoBalances",
+export const registrarOutput: CollectionRegistrar = {
+  name: "runes_outputs",
   indexes: [
     [{ txid: 1, vout: 1, runeTicker: 1 }, { unique: true }],
     [{ address: 1 }],
@@ -21,14 +20,5 @@ export const registrarUtxoBalance: CollectionRegistrar = {
   ],
 };
 
-export const registrarRunes: CollectionRegistrar = {
-  name: "runes",
-  indexes: [
-    [{ runeTicker: 1 }, { unique: true }],
-    [{ runeId: 1 }, { unique: true }],
-  ],
-};
-
-export type Mint = { block: number; count: number };
-export type Burned = RuneBalance & { block: number };
-export type RuneEntry = RuneEtching & { mints: Mint[]; burned: Burned[] };
+export type RuneOutput = RuneUtxoBalance & { txBlockHeight: number; spentTxid?: string }; // txBlockHeight needed for reorg
+export type SimplifiedRuneBlockIndex = Omit<RuneBlockIndex, "utxoBalances" | "spentBalances">;

--- a/src/Database/Runes/Collection.ts
+++ b/src/Database/Runes/Collection.ts
@@ -1,8 +1,9 @@
-import { RuneBlockIndex, RuneUtxoBalance } from "runestone-lib";
+import { RuneBlockIndex, RuneEtching, RuneUtxoBalance } from "runestone-lib";
 
 import { CollectionRegistrar, mongo } from "~Services/Mongo";
 
 export const collectionBlockInfo = mongo.db.collection<SimplifiedRuneBlockIndex>("runes_blocks");
+export const collectionEtching = mongo.db.collection<RuneEtching>("runes_etchings");
 export const collectionOutputs = mongo.db.collection<RuneOutput>("runes_outputs");
 
 export const registrarBlockInfo: CollectionRegistrar = {
@@ -10,15 +11,20 @@ export const registrarBlockInfo: CollectionRegistrar = {
   indexes: [[{ "block.height": 1 }, { unique: true }]],
 };
 
+export const registrarEtching: CollectionRegistrar = {
+  name: "runes_etchings",
+  indexes: [[{ runeTicker: 1 }, { unique: true }]],
+};
+
 export const registrarOutput: CollectionRegistrar = {
   name: "runes_outputs",
   indexes: [
     [{ txid: 1, vout: 1, runeTicker: 1 }, { unique: true }],
+    [{ txid: 1, vout: 1 }],
     [{ address: 1 }],
-    [{ runeTicker: 1 }],
     [{ address: 1, runeTicker: 1 }],
   ],
 };
 
 export type RuneOutput = RuneUtxoBalance & { txBlockHeight: number; spentTxid?: string }; // txBlockHeight needed for reorg
-export type SimplifiedRuneBlockIndex = Omit<RuneBlockIndex, "utxoBalances" | "spentBalances">;
+export type SimplifiedRuneBlockIndex = Omit<RuneBlockIndex, "utxoBalances" | "spentBalances" | "reorg">;

--- a/src/Database/Runes/Methods.ts
+++ b/src/Database/Runes/Methods.ts
@@ -2,7 +2,7 @@ import { BlockIdentifier, RuneBlockIndex, RuneEtching, RuneLocation, RuneUtxoBal
 
 import { FindPaginatedParams, paginate } from "~Libraries/Paginate";
 import { client, mongo } from "~Services/Mongo";
-import { convertBigIntToString } from "~Utilities/Helpers";
+import { convertBigIntToString, convertStringToBigInt } from "~Utilities/Helpers";
 
 import { collectionBlockInfo, collectionOutputs, RuneOutput, SimplifiedRuneBlockIndex } from "./Collection";
 
@@ -181,7 +181,7 @@ async function getEtching(runeLocation: string): Promise<RuneEtching | null> {
     (etching) => etching.runeId.block === runeId.block && etching.runeId.tx === runeId.tx,
   );
 
-  return etching || null;
+  return convertStringToBigInt(etching) || null;
 }
 
 async function getValidMintCount(runeLocation: string, blockheight: number): Promise<number> {
@@ -228,5 +228,7 @@ async function getRuneLocation(runeTicker: string): Promise<RuneLocation | null>
 }
 
 async function getUtxoBalance(txid: string, vout: number): Promise<RuneUtxoBalance[]> {
-  return await collectionOutputs.find<RuneUtxoBalance>({ txid, vout }).toArray();
+  const utxoBalance = await collectionOutputs.find<RuneUtxoBalance>({ txid, vout }).toArray();
+  const utxoBalanceFlat = utxoBalance.map((utxo) => convertStringToBigInt(utxo));
+  return utxoBalanceFlat;
 }

--- a/src/Database/Runes/Methods.ts
+++ b/src/Database/Runes/Methods.ts
@@ -1,25 +1,21 @@
-import { Filter } from "mongodb";
-import { BlockIdentifier, BlockInfo, RuneBlockIndex, RuneEtching, RuneLocation, RuneUtxoBalance } from "runestone-lib";
+import { BlockIdentifier, RuneBlockIndex, RuneEtching, RuneLocation, RuneUtxoBalance } from "runestone-lib";
 
-import { ignoreDuplicateErrors } from "~Database/Utilities";
 import { FindPaginatedParams, paginate } from "~Libraries/Paginate";
 import { client, mongo } from "~Services/Mongo";
-import { convertBigIntToString, convertStringToBigInt } from "~Utilities/Helpers";
+import { convertBigIntToString } from "~Utilities/Helpers";
 
-import { collectionBlocks, collectionRunes, collectionUtxoBalances, Mint, RuneEntry } from "./Collection";
+import { collectionBlockInfo, collectionOutputs, RuneOutput, SimplifiedRuneBlockIndex } from "./Collection";
 
 export const runes = {
   ...mongo,
-  collectionBlocks,
-  collectionRunes,
-  collectionUtxoBalances,
+  collectionBlockInfo,
+  collectionOutputs,
 
   // Core Methods
-  findRune,
-  findRunes,
-  countBlocks,
+  getEtchingByTicker,
   addressBalances,
   addressRunesUTXOs,
+  saveBlocksInBatch,
 
   // RunestoneStorage implementation
   disconnect,
@@ -30,55 +26,50 @@ export const runes = {
   getUtxoBalance,
   getValidMintCount,
   resetCurrentBlock,
-  resetCurrentBlockHeight,
   saveBlockIndex,
   seedEtchings,
 };
 
-async function countBlocks(filter: Filter<BlockInfo>) {
-  return collectionBlocks.countDocuments(filter);
+async function getEtchingByTicker(runeTicker: string): Promise<RuneEtching | null> {
+  const result = await collectionBlockInfo
+    .aggregate<RuneEtching>([
+      { $unwind: "$etchings" },
+      { $match: { "etchings.runeTicker": runeTicker } },
+      { $replaceRoot: { newRoot: "$etchings" } },
+      { $limit: 1 },
+    ])
+    .toArray();
+
+  return result.length > 0 ? result[0] : null;
 }
 
-async function findRune(
-  runeTicker: string,
-  verbose: boolean = false,
-): Promise<RuneEntry | Partial<Omit<RuneEntry, "mints">> | null> {
-  const filter = { runeTicker };
-  const rune = await collectionRunes.findOne<RuneEntry>(filter);
-  if (!rune) return null;
-  if (verbose) return rune;
+export async function addressBalances(address: string): Promise<{ runeTicker: string; balance: string }[]> {
+  const result = await collectionOutputs
+    .aggregate<{ runeTicker: string; balance: string }>([
+      {
+        $match: { address, spentTxid: { $exists: false } },
+      },
+      {
+        $group: {
+          _id: "$runeTicker",
+          totalBalance: { $sum: { $toDouble: "$amount" } },
+        },
+      },
+      {
+        $project: {
+          _id: 0,
+          runeTicker: "$_id",
+          balance: { $toString: "$totalBalance" },
+        },
+      },
+    ])
+    .toArray();
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { mints, ...runeWithoutMints } = rune;
-  return runeWithoutMints;
+  return result;
 }
 
-async function findRunes(
-  runeTickers: string[],
-  verbose: boolean = false,
-): Promise<(RuneEntry | Partial<Omit<RuneEntry, "mints">>)[]> {
-  const filter = { runeTicker: { $in: runeTickers } };
-  const runes = await collectionRunes.find<RuneEntry>(filter).toArray();
-
-  if (verbose) return runes;
-
-  return runes.map((rune) => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { mints, ...runeWithoutMints } = rune;
-    return runeWithoutMints;
-  });
-}
-
-async function addressBalances(address: string, withSpents: boolean = false): Promise<RuneUtxoBalance[]> {
-  let filter: Filter<RuneUtxoBalance> = { address };
-  if (!withSpents) {
-    filter = { address, spentTxid: { $exists: false } };
-  }
-  return await collectionUtxoBalances.find<RuneUtxoBalance>(filter).toArray();
-}
-
-async function addressRunesUTXOs(params: FindPaginatedParams<RuneUtxoBalance> = {}) {
-  return paginate.findPaginated(collectionUtxoBalances, params);
+async function addressRunesUTXOs(params: FindPaginatedParams<RuneOutput> = {}) {
+  return paginate.findPaginated(collectionOutputs, params);
 }
 
 /**
@@ -89,159 +80,153 @@ async function disconnect() {
 }
 
 async function getBlockhash(blockHeight: number): Promise<string | null> {
-  const block = await collectionBlocks.findOne({ height: blockHeight });
-  return block ? block.hash : null;
+  const runeBlockInfo = await collectionBlockInfo.findOne({ "block.height": blockHeight });
+  return runeBlockInfo ? runeBlockInfo.block.hash : null;
 }
 
 async function getCurrentBlock(): Promise<BlockIdentifier | null> {
-  const block = await collectionBlocks.find().sort({ height: -1 }).limit(1).next();
-  return block ? { height: block.height, hash: block.hash } : null;
+  const runeBlockInfo = await collectionBlockInfo.find().sort({ "block.height": -1 }).limit(1).next();
+  return runeBlockInfo ? { height: runeBlockInfo.block.height, hash: runeBlockInfo.block.hash } : null;
 }
 
 async function resetCurrentBlock(block: BlockIdentifier): Promise<void> {
-  await collectionBlocks.deleteMany({ height: { $gt: block.height } });
-
-  await collectionBlocks.updateOne({ height: block.height }, { $set: { hash: block.hash } }, { upsert: true });
+  await collectionOutputs.deleteMany({ txBlockHeight: { $gt: block.height } });
+  await collectionBlockInfo.deleteMany({ "block.height": { $gt: block.height } });
 }
 
-async function resetCurrentBlockHeight(height: number): Promise<void> {
-  await collectionBlocks.deleteMany({ height: { $gt: height } });
-  const hash = await getBlockhash(height);
-  if (!hash) {
-    throw new Error(`Error getting block hash ${height}`);
+export async function seedEtchings(runesEtchings: RuneEtching[]): Promise<void> {
+  for (const etching of runesEtchings) {
+    if (!etching.valid) continue;
+
+    const blockHeight = etching.runeId.block;
+    const filter = { "block.height": blockHeight };
+
+    const existingDocument = await collectionBlockInfo.findOne(filter);
+    if (existingDocument) {
+      await collectionBlockInfo.updateOne(filter, { $push: { etchings: etching } });
+    } else {
+      const newDocument: SimplifiedRuneBlockIndex = {
+        block: {
+          height: blockHeight,
+          hash: etching.txid,
+          previousblockhash: "---",
+          time: 0,
+        },
+        reorg: false,
+        etchings: [etching],
+        mintCounts: [],
+        burnedBalances: [],
+      };
+
+      await collectionBlockInfo.insertOne(newDocument);
+    }
   }
-
-  await collectionBlocks.updateOne({ height }, { $set: { hash } }, { upsert: true });
-}
-
-async function seedEtchings(runes_etchings: RuneEtching[]): Promise<void> {
-  const bulkOps = runes_etchings.map((etching) => ({
-    insertOne: {
-      document: convertBigIntToString(etching),
-    },
-  }));
-
-  await collectionRunes.bulkWrite(bulkOps);
 }
 
 async function saveBlockIndex(runeBlockIndex: RuneBlockIndex): Promise<void> {
-  await collectionBlocks.insertOne(runeBlockIndex.block).catch(ignoreDuplicateErrors);
+  const filter = { "block.height": runeBlockIndex.block.height };
 
-  // RUNE ENTRY
-  const bulkEtchings = runeBlockIndex.etchings.map((etching) => ({
-    insertOne: {
-      document: convertBigIntToString(etching),
-    },
-  }));
+  const sanitizedBlockIndex = convertBigIntToString(runeBlockIndex);
 
-  if (bulkEtchings.length > 0) await collectionRunes.bulkWrite(bulkEtchings).catch(ignoreDuplicateErrors);
+  await collectionBlockInfo.updateOne(filter, { $set: sanitizedBlockIndex }, { upsert: true });
 
-  // RUNE UTXOS
-  const bulkUtxoBalances = runeBlockIndex.utxoBalances.map((utxo) => {
-    const { amount, ...rest } = utxo;
+  if (runeBlockIndex.utxoBalances && runeBlockIndex.utxoBalances.length > 0) {
+    const newUtxos = runeBlockIndex.utxoBalances.map((utxo) => ({
+      ...utxo,
+      txBlockHeight: runeBlockIndex.block.height,
+    }));
 
-    return {
-      insertOne: {
-        document: {
-          ...rest,
-          amount: amount.toString(),
-        },
-      },
-    };
-  });
-
-  if (bulkUtxoBalances.length > 0)
-    await collectionUtxoBalances.bulkWrite(bulkUtxoBalances).catch(ignoreDuplicateErrors);
-
-  // RUNE SPENTS
-  const bulkSpentBalances = runeBlockIndex.spentBalances.map((spent) => ({
-    updateOne: {
-      filter: { txid: spent.txid, vout: spent.vout },
-      update: { $set: { spentTxid: spent.spentTxid } },
-    },
-  }));
-
-  if (bulkSpentBalances.length > 0) await collectionUtxoBalances.bulkWrite(bulkSpentBalances);
-
-  // RUNE MINTS
-  const bulkMintCounts = runeBlockIndex.mintCounts.map((mintCount) => {
-    const mint: Mint = {
-      block: runeBlockIndex.block.height,
-      count: mintCount.count,
-    };
-
-    return {
-      updateOne: {
-        filter: { runeId: mintCount.mint },
-        update: {
-          $push: { mints: mint },
-        },
-        upsert: true,
-      },
-    };
-  });
-
-  if (bulkMintCounts.length > 0) {
-    await collectionRunes.bulkWrite(bulkMintCounts);
+    await collectionOutputs.insertMany(newUtxos);
   }
 
-  // RUNE BURNT
-  const bulkBurnedBalances = runeBlockIndex.burnedBalances.map((burned) => ({
-    deleteOne: {
-      filter: { "runeId.block": burned.runeId.block, "runeId.tx": burned.runeId.tx },
-    },
-  }));
-
-  if (bulkBurnedBalances.length > 0) {
-    await collectionUtxoBalances.bulkWrite(bulkBurnedBalances);
+  for (const spentUtxo of runeBlockIndex.spentBalances) {
+    await collectionOutputs.updateOne(
+      { txid: spentUtxo.txid, vout: spentUtxo.vout },
+      { $set: { spentTxid: spentUtxo.spentTxid, blockHeight: runeBlockIndex.block.height } },
+    );
   }
 }
+
+async function saveBlocksInBatch(runeBlockIndexes: RuneBlockIndex[]): Promise<void> {
+  const session = client.startSession();
+
+  try {
+    await session.withTransaction(async () => {
+      for (const runeBlockIndex of runeBlockIndexes) {
+        await saveBlockIndex(runeBlockIndex);
+      }
+    });
+
+    console.log("✅ Transaction committed successfully");
+  } catch (error) {
+    console.error("Error saving blocks in batch, transaction aborted:", error);
+    throw error;
+  } finally {
+    session.endSession();
+  }
+}
+
 async function getEtching(runeLocation: string): Promise<RuneEtching | null> {
-  const runeLocSplit = runeLocation.split(":", 2);
-  const _runeLocation: RuneLocation = {
-    block: Number(runeLocSplit[0]),
-    tx: Number(runeLocSplit[1]),
+  const [blockHeightStr, txStr] = runeLocation.split(":");
+  const runeId: RuneLocation = {
+    block: parseInt(blockHeightStr, 10),
+    tx: parseInt(txStr, 10),
   };
-  const etching = await collectionRunes.findOne({ runeId: _runeLocation });
-  convertStringToBigInt(etching);
-  return etching ? (etching as unknown as RuneEtching) : null;
+
+  const document = await collectionBlockInfo.findOne<RuneBlockIndex>({ "block.height": runeId.block });
+
+  if (!document) return null;
+
+  const etching = document.etchings.find(
+    (etching) => etching.runeId.block === runeId.block && etching.runeId.tx === runeId.tx,
+  );
+
+  return etching || null;
 }
 
 async function getValidMintCount(runeLocation: string, blockheight: number): Promise<number> {
-  const runeLocSplit = runeLocation.split(":", 2);
-  const _runeLocation: RuneLocation = {
-    block: Number(runeLocSplit[0]),
-    tx: Number(runeLocSplit[1]),
+  const [blockStr, txStr] = runeLocation.split(":");
+  const targetRuneLocation: RuneLocation = {
+    block: parseInt(blockStr, 10),
+    tx: parseInt(txStr, 10),
   };
 
-  const runeEntry = await collectionRunes.findOne({ runeId: _runeLocation });
+  const result = await collectionBlockInfo
+    .aggregate<{ totalMintCount: number }>([
+      { $match: { "block.height": { $lte: blockheight } } },
+      { $unwind: "$mintCounts" },
+      {
+        $match: {
+          "mintCounts.mint.block": targetRuneLocation.block,
+          "mintCounts.mint.tx": targetRuneLocation.tx,
+        },
+      },
+      {
+        $group: {
+          _id: null,
+          totalMintCount: { $sum: "$mintCounts.count" },
+        },
+      },
+      { $project: { _id: 0, totalMintCount: 1 } },
+    ])
+    .toArray();
 
-  if (!runeEntry || !runeEntry.mints) {
-    return 0;
-  }
-
-  const validMints = runeEntry.mints.filter((mint: Mint) => mint.block <= blockheight);
-  const totalCount = validMints.reduce((sum: number, mint: Mint) => sum + mint.count, 0);
-
-  return totalCount;
+  return result.length > 0 ? result[0].totalMintCount : 0;
 }
 
 async function getRuneLocation(runeTicker: string): Promise<RuneLocation | null> {
-  const etching = await collectionRunes.findOne({ runeTicker });
-  convertStringToBigInt(etching);
-  return etching ? (etching.runeId as RuneLocation) : null;
+  const result = await collectionBlockInfo
+    .aggregate<RuneLocation>([
+      { $unwind: "$etchings" },
+      { $match: { "etchings.runeTicker": runeTicker } },
+      { $project: { _id: 0, runeId: "$etchings.runeId" } },
+      { $limit: 1 },
+    ])
+    .toArray();
+
+  return result.length > 0 ? result[0] : null;
 }
 
 async function getUtxoBalance(txid: string, vout: number): Promise<RuneUtxoBalance[]> {
-  const balances = await collectionUtxoBalances.find({ txid, vout }).toArray();
-  return balances.map((balance) => ({
-    txid: balance.txid,
-    vout: balance.vout,
-    address: balance.address,
-    scriptPubKey: balance.scriptPubKey,
-    runeId: balance.runeId,
-    satValue: balance.satValue,
-    runeTicker: balance.runeTicker,
-    amount: BigInt(balance.amount),
-  }));
+  return await collectionOutputs.find<RuneUtxoBalance>({ txid, vout }).toArray();
 }

--- a/src/Database/Runes/index.ts
+++ b/src/Database/Runes/index.ts
@@ -1,8 +1,9 @@
 export * from "./Collection";
 export * from "./Methods.ts";
-import { collectionBlockInfo, collectionOutputs } from "~Database/Runes";
+import { collectionBlockInfo, collectionEtching, collectionOutputs } from "~Database/Runes";
 
 export const runesColletcions = {
   collectionBlockInfo,
+  collectionEtching,
   collectionOutputs,
 };

--- a/src/Database/Runes/index.ts
+++ b/src/Database/Runes/index.ts
@@ -1,13 +1,8 @@
 export * from "./Collection";
 export * from "./Methods.ts";
-import { collectionBlocks, collectionRunes, collectionUtxoBalances } from "~Database/Runes";
+import { collectionBlockInfo, collectionOutputs } from "~Database/Runes";
 
-export const runesBlocks = {
-  collectionBlocks,
-};
-export const runesEtchings = {
-  collectionRunes,
-};
-export const runesUtxoBalances = {
-  collectionUtxoBalances,
+export const runesColletcions = {
+  collectionBlockInfo,
+  collectionOutputs,
 };

--- a/src/Database/index.ts
+++ b/src/Database/index.ts
@@ -4,7 +4,7 @@ import { inscriptions } from "./Inscriptions";
 import { ipfs } from "./IPFS";
 import { media } from "./Media";
 import { outputs } from "./Output";
-import { runesBlocks, runesEtchings, runesMintCounts, runesUtxoBalances } from "./Runes";
+import { runes } from "./Runes";
 import { sado } from "./Sado";
 import { utxos } from "./Utxos";
 
@@ -15,10 +15,7 @@ export const db = {
   ipfs,
   media,
   outputs,
-  runesBlocks,
-  runesEtchings,
-  runesMintCounts,
-  runesUtxoBalances,
+  runes,
   sado,
   utxos,
 };

--- a/src/Libraries/Indexer/Indexer.ts
+++ b/src/Libraries/Indexer/Indexer.ts
@@ -126,7 +126,7 @@ export class Indexer {
     let height = currentHeight + 1;
     let blockHash: string | undefined = await rpc.blockchain.getBlockHash(height);
 
-    let startHeight = currentHeight;
+    let startHeight = height;
 
     const blockLimiter = limiter(config.index.blockConcurrencyLimit ?? 8);
 
@@ -144,9 +144,10 @@ export class Indexer {
       // to the registered index handlers.
 
       if (this.#hasReachedBlocksCommitThreshold(height)) {
-        log(`\n💽 Read blocks [${startHeight.toLocaleString()} - ${height.toLocaleString()}][${ts.now} seconds]`);
+        log(`\n💽 Reading blocks [${startHeight.toLocaleString()} - ${height.toLocaleString()}]`);
         startHeight = height;
         await blockLimiter.run();
+        console.log(`⌚ ${ts.now} seconds`);
         await this.#commit(height);
         ts = perf();
       }

--- a/src/Libraries/Indexer/Indexer.ts
+++ b/src/Libraries/Indexer/Indexer.ts
@@ -72,7 +72,7 @@ export class Indexer {
     log(`---------- indexing to block ${blockHeight.toLocaleString()} ----------`);
 
     const reorgHeight = await this.#reorgCheck(currentHeight);
-    if (reorgHeight !== undefined) {
+    if (reorgHeight !== undefined && currentHeight > reorgHeight) {
       currentHeight = reorgHeight;
     }
     await this.#indexBlocks(currentHeight, blockHeight);

--- a/src/Libraries/Indexer/Indexer.ts
+++ b/src/Libraries/Indexer/Indexer.ts
@@ -169,10 +169,10 @@ export class Indexer {
 
       if (this.#hasReachedBlocksCommitThreshold(height)) {
         log(`\n💽 Reading blocks [${startHeight.toLocaleString()} - ${height.toLocaleString()}]`);
-        startHeight = height;
         await blockLimiter.run();
         console.log(`⌚ ${ts.now} seconds`);
         await this.#commit(height);
+        startHeight = height + 1;
         ts = perf();
       }
 

--- a/src/Libraries/Indexer/Reorg.ts
+++ b/src/Libraries/Indexer/Reorg.ts
@@ -16,8 +16,14 @@ export async function getReorgHeight(): Promise<number> {
   while (currentHeight > targetHeight) {
     logProgress(currentHeight, targetHeight, reorgHeight);
 
-    const block = await rpc.blockchain.getBlock(currentHeight);
-    if (block === undefined) {
+    let block: any;
+    try {
+      block = await rpc.blockchain.getBlock(currentHeight);
+      if (block === undefined) {
+        currentHeight -= 1;
+        continue;
+      }
+    } catch (e) {
       currentHeight -= 1;
       continue;
     }

--- a/src/Libraries/Runes/Constants.ts
+++ b/src/Libraries/Runes/Constants.ts
@@ -4,7 +4,7 @@ export const RUNES_BLOCK =
   config.network === "mainnet"
     ? 840_000
     : config.network === "testnet"
-    ? 2520000
-    : config.network === "signet"
-    ? 188_714
-    : 0;
+      ? 2583205
+      : config.network === "signet"
+        ? 188_714
+        : 0;

--- a/src/Methods/Runes/GetAddressRuneUTXOIndex.ts
+++ b/src/Methods/Runes/GetAddressRuneUTXOIndex.ts
@@ -1,11 +1,8 @@
 import { method } from "@valkyr/api";
-import Schema, { boolean, string } from "computed-types";
+import Schema, { string } from "computed-types";
 import { Filter } from "mongodb";
-import { RuneUtxoBalance } from "runestone-lib";
 
-import { db } from "~Database";
-import { OutputDocument } from "~Database/Output";
-import { runes } from "~Database/Runes";
+import { RuneOutput, runes } from "~Database/Runes";
 import { FindPaginatedParams } from "~Libraries/Paginate";
 
 import { schema } from "../../Libraries/Schema";
@@ -16,21 +13,18 @@ export default method({
     runeTicker: string.optional(),
     pagination: schema.pagination.optional(),
     sort: schema.sort,
-    includeSpent: boolean.optional(),
-    includeSatValue: boolean.optional(),
   }),
-  handler: async ({ address, runeTicker, pagination = {}, sort, includeSpent = false, includeSatValue = false }) => {
-    pagination.limit ??= 50;
+  handler: async ({ address, runeTicker, pagination = {}, sort }) => {
+    pagination.limit ??= 100;
     sort ??= { _id: "asc" };
 
-    const filter: Filter<RuneUtxoBalance> = { address };
-    if (runeTicker) {
-      filter.runeTicker = runeTicker;
-    }
-    if (!includeSpent) {
-      filter.spentTxid = { $exists: false };
-    }
-    const params: FindPaginatedParams<RuneUtxoBalance> = {
+    const filter: Filter<RuneOutput> = {
+      address,
+      ...(runeTicker && { runeTicker }),
+      spentTxid: { $exists: false },
+    };
+
+    const params: FindPaginatedParams<RuneOutput> = {
       ...pagination,
       filter,
       sort,
@@ -38,17 +32,6 @@ export default method({
     };
 
     const balances = await runes.addressRunesUTXOs(params);
-    if (includeSatValue) {
-      await Promise.all(
-        balances.documents.map(async (balance: any) => {
-          const filter: Filter<OutputDocument> = { "vout.txid": balance.txid, "vout.n": balance.vout };
-          const vout = await db.outputs.findOne(filter);
-          if (vout?.value) {
-            balance.value = vout.value;
-          }
-        }),
-      );
-    }
     return {
       balances: balances.documents,
       pagination: balances.pagination,

--- a/src/Methods/Runes/GetRuneIndex.ts
+++ b/src/Methods/Runes/GetRuneIndex.ts
@@ -1,18 +1,13 @@
-import { method, NotFoundError } from "@valkyr/api";
-import Schema, { boolean, string } from "computed-types";
+import { method } from "@valkyr/api";
+import Schema, { string } from "computed-types";
 
 import { runes } from "~Database/Runes";
 
 export default method({
   params: Schema({
     runeTicker: string,
-    verbose: boolean.optional(),
   }),
-  handler: async ({ runeTicker, verbose = false }) => {
-    const rune = await runes.findRune(runeTicker, verbose);
-    if (rune === undefined) {
-      throw new NotFoundError("Rune not found");
-    }
-    return rune;
+  handler: async ({ runeTicker }) => {
+    return await runes.getEtchingByTicker(runeTicker);
   },
 });

--- a/src/Utilities/Helpers.ts
+++ b/src/Utilities/Helpers.ts
@@ -35,27 +35,24 @@ export function convertStringToBigInt(obj: any): any {
   return obj;
 }
 
-export function convertBigIntToString(obj: any): any {
-  if (obj === null || obj === undefined) return obj;
+export function convertBigIntToString(obj: any, seen = new WeakSet()): any {
+  if (obj && typeof obj === "object") {
+    if (seen.has(obj)) return obj; // Return the object as-is if already processed
 
-  if (typeof obj === "bigint") {
-    return obj.toString();
-  }
+    seen.add(obj);
 
-  if (Array.isArray(obj)) {
-    return obj.map(convertBigIntToString);
-  }
-
-  if (typeof obj === "object") {
-    const newObj: any = {};
     for (const key in obj) {
-      // eslint-disable-next-line no-prototype-builtins
-      if (obj.hasOwnProperty(key)) {
-        // eslint-disable-next-line no-prototype-builtins
-        newObj[key] = convertBigIntToString(obj[key]);
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        const value = obj[key];
+        if (typeof value === "bigint") {
+          obj[key] = value.toString();
+        } else if (typeof value === "object" && value !== null) {
+          convertBigIntToString(value, seen);
+        }
       }
     }
-    return newObj;
+  } else if (Array.isArray(obj)) {
+    return obj.map((item) => convertBigIntToString(item, seen));
   }
 
   return obj;

--- a/src/Utilities/Helpers.ts
+++ b/src/Utilities/Helpers.ts
@@ -1,3 +1,5 @@
+import { Long } from "bson";
+
 export async function sleep(seconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
 }
@@ -16,16 +18,23 @@ export function convertStringToBigInt(obj: any): any {
     }
   }
 
+  if (typeof obj === "bigint") {
+    return obj;
+  }
+
   if (Array.isArray(obj)) {
     return obj.map(convertStringToBigInt);
   }
 
   if (typeof obj === "object") {
+    // Check if the object is a BSON Long
+    if (Long.isLong(obj)) {
+      return obj.toBigInt();
+    }
+
     const newObj: any = {};
     for (const key in obj) {
-      // eslint-disable-next-line no-prototype-builtins
-      if (obj.hasOwnProperty(key)) {
-        // eslint-disable-next-line no-prototype-builtins
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
         newObj[key] = convertStringToBigInt(obj[key]);
       }
     }

--- a/src/Utilities/Runes.ts
+++ b/src/Utilities/Runes.ts
@@ -1,22 +1,7 @@
-import { isRunestone, tryDecodeRunestone } from "runestone-lib";
-
-import { rpc } from "~Services/Bitcoin";
+import { runes } from "~Database/Runes";
 
 export async function outputHasRunes(outpoint: string): Promise<boolean> {
   const [txid, n] = outpoint.split(":");
-  const tx = await rpc.transactions.getRawTransaction(txid, true);
-  if (!tx) return false;
-  const decipher = tryDecodeRunestone(tx);
-  if (!decipher) return false;
-  if (!isRunestone(decipher)) return false;
-
-  const pointer = decipher.pointer ?? 1;
-  if (decipher.etching || decipher.mint) {
-    if (Number(n) === pointer) return true;
-  }
-  if (decipher.edicts) {
-    return decipher.edicts.some((edict) => Number(n) === edict.output);
-  }
-
-  return false;
+  const balances = await runes.getUtxoBalance(txid, Number(n));
+  return balances.length > 0;
 }

--- a/src/Workers/Index.ts
+++ b/src/Workers/Index.ts
@@ -13,10 +13,6 @@ export async function index() {
   const blockHeight = await rpc.blockchain.getBlockCount();
   const indexers: IndexHandler[] = [];
 
-  if (config.index.outputs === true) {
-    indexers.push(outputIndexer);
-  }
-
   if (config.index.utxos === true) {
     indexers.push(utxoIndexer);
   }
@@ -34,6 +30,10 @@ export async function index() {
 
   if (config.index.runes === true) {
     indexers.push(runesIndexer);
+  }
+
+  if (config.index.outputs === true) {
+    indexers.push(outputIndexer);
   }
 
   const indexer = new Indexer({ indexers });

--- a/src/Workers/Index.ts
+++ b/src/Workers/Index.ts
@@ -13,27 +13,31 @@ export async function index() {
   const blockHeight = await rpc.blockchain.getBlockCount();
   const indexers: IndexHandler[] = [];
 
-  if (config.index.utxos === true) {
-    indexers.push(utxoIndexer);
-  }
-
-  if (config.index.inscriptions === true) {
-    indexers.push(inscriptionsIndexer);
-    if (config.index.brc20 === true) {
-      indexers.push(brc20Indexer);
+  if (!config.index.runesOnly) {
+    if (config.index.utxos === true) {
+      indexers.push(utxoIndexer);
     }
-  }
 
-  if (config.index.sado === true) {
-    indexers.push(sadoIndexer);
-  }
+    if (config.index.inscriptions === true) {
+      indexers.push(inscriptionsIndexer);
+      if (config.index.brc20 === true) {
+        indexers.push(brc20Indexer);
+      }
+    }
 
-  if (config.index.runes === true) {
+    if (config.index.sado === true) {
+      indexers.push(sadoIndexer);
+    }
+
+    if (config.index.runes === true) {
+      indexers.push(runesIndexer);
+    }
+
+    if (config.index.outputs === true) {
+      indexers.push(outputIndexer);
+    }
+  } else {
     indexers.push(runesIndexer);
-  }
-
-  if (config.index.outputs === true) {
-    indexers.push(outputIndexer);
   }
 
   const indexer = new Indexer({ indexers });

--- a/src/Workers/Indexers/Inscriptions.ts
+++ b/src/Workers/Indexers/Inscriptions.ts
@@ -17,7 +17,7 @@ export const inscriptionsIndexer: IndexHandler = {
       return;
     }
 
-    log(`[Inscriptions indexer]`);
+    log(`\n[Inscriptions indexer]`);
     let ts = perf();
     log(`⏳ Waiting for block ${height.toLocaleString()}`);
     await ord.waitForBlock(height);

--- a/src/Workers/Indexers/Outputs.ts
+++ b/src/Workers/Indexers/Outputs.ts
@@ -8,7 +8,7 @@ export const outputIndexer: IndexHandler = {
 
   async run(indexer: Indexer, { log }) {
     let ts = perf();
-    log(`[Outputs indexer]`);
+    log(`\n[Outputs indexer]`);
 
     const outputs: OutputDocument[] = [];
     const spents: SpentOutput[] = [];

--- a/src/Workers/Indexers/Runes.ts
+++ b/src/Workers/Indexers/Runes.ts
@@ -29,7 +29,6 @@ export const runesIndexer: IndexHandler = {
     for (const block of blocks) {
       const runeUpdater = new RuneUpdater(network, block, false, runes, blockchain);
 
-      log(`🔍 [${block.height}] Processing ${block.tx.length} transactions`);
       for (const [txIndex, tx] of block.tx.entries()) {
         await runeUpdater.indexRunes(tx, txIndex);
       }
@@ -53,9 +52,9 @@ export const runesIndexer: IndexHandler = {
           burnedBalances,
         };
         runeBlockIndexes.push(runeBlockIndex);
+        printBlockInfo(runeBlockIndex);
       }
     }
-    console.log(`🪛 ${runeBlockIndexes.length} runestones processed`);
     if (runeBlockIndexes.length > 0) await runes.saveBlocksInBatch(runeBlockIndexes);
   },
 
@@ -63,3 +62,14 @@ export const runesIndexer: IndexHandler = {
     await runes.resetCurrentBlock({ height, hash: "" });
   },
 };
+
+function printBlockInfo(runeBlockIndex: RuneBlockIndex) {
+  const blockStr = `${runeBlockIndex.block.height}`.padEnd(6, " ");
+  const etchingsStr = `${runeBlockIndex.etchings.length.toLocaleString()} etchings`.padStart(12, " ");
+  const balancesStr = `${runeBlockIndex.utxoBalances.length.toLocaleString()} balances`.padStart(12, " ");
+  const spentStr = `${runeBlockIndex.spentBalances.length.toLocaleString()} spent`.padStart(9, " ");
+  const burntStr = `${runeBlockIndex.burnedBalances.length.toLocaleString()} burnt`.padStart(9, " ");
+  const mintStr = `${runeBlockIndex.mintCounts.length.toLocaleString()} mint`.padStart(9, " ");
+
+  console.log(`🔍 ${blockStr}:${etchingsStr},${balancesStr},${spentStr},${burntStr},${mintStr}`);
+}

--- a/src/Workers/Indexers/Runes.ts
+++ b/src/Workers/Indexers/Runes.ts
@@ -1,8 +1,7 @@
-import { RuneUpdater } from "runestone-lib";
+import { RuneBlockIndex, RuneUpdater } from "runestone-lib";
 
 import { runes } from "~Database/Runes";
 import { Indexer, IndexHandler } from "~Libraries/Indexer/Indexer";
-import { perf } from "~Libraries/Log";
 import { getNetworkEnum } from "~Libraries/Network";
 import { RUNES_BLOCK } from "~Libraries/Runes/Constants";
 import { blockchain } from "~Services/Bitcoin";
@@ -11,70 +10,55 @@ export const runesIndexer: IndexHandler = {
   name: "runes",
 
   async run(idx: Indexer, { height, log }) {
-    if (height < RUNES_BLOCK) {
-      return;
-    }
-    log(`[Runes indexer]`);
+    if (height < RUNES_BLOCK) return;
+    if (idx.blocks.length === 0) return;
+    console.log(`\n[Runes indexer]`);
     const network = getNetworkEnum();
-
     // order blocks
     const blocks = idx.blocks.sort((a, b) => a.height - b.height);
 
+    // check reorg for runes
+    const initialHeight = blocks[0].height;
+    const runesIndexHeight = await runes.getCurrentBlock();
+    if (runesIndexHeight && runesIndexHeight?.height > initialHeight) {
+      await runes.resetCurrentBlock({ height: initialHeight, hash: "" });
+    }
+
+    const runeBlockIndexes: RuneBlockIndex[] = [];
+    log(`🔍 Looking for runestones in blocks...`);
     for (const block of blocks) {
-      const ts = perf();
       const runeUpdater = new RuneUpdater(network, block, false, runes, blockchain);
 
       for (const [txIndex, tx] of block.tx.entries()) {
         await runeUpdater.indexRunes(tx, txIndex);
       }
-      const etchingsLength = runeUpdater.etchings.length;
-      const utxoBalancesLength = runeUpdater.utxoBalances.length;
-      const spentBalancesLength = runeUpdater.spentBalances.length;
-      const burnedBalancesLength = runeUpdater.burnedBalances.length;
-      const mintCountsLength = runeUpdater.mintCounts.length;
 
+      const { etchings, mintCounts, utxoBalances, spentBalances, burnedBalances } = runeUpdater;
       const foundRunestone =
-        etchingsLength || utxoBalancesLength || spentBalancesLength || burnedBalancesLength || mintCountsLength;
-      await runes.saveBlockIndex(runeUpdater);
+        etchings.length || mintCounts.length || utxoBalances.length || spentBalances.length || burnedBalances.length;
       if (foundRunestone) {
-        printBlockInfo(
-          block.height,
-          etchingsLength,
-          utxoBalancesLength,
-          spentBalancesLength,
-          burnedBalancesLength,
-          mintCountsLength,
-          ts.now,
-        );
+        const runeBlockIndex: RuneBlockIndex = {
+          block: {
+            height: block.height,
+            hash: block.hash,
+            previousblockhash: block.previousblockhash,
+            time: block.time,
+          },
+          reorg: false,
+          etchings,
+          mintCounts,
+          utxoBalances,
+          spentBalances,
+          burnedBalances,
+        };
+        runeBlockIndexes.push(runeBlockIndex);
       }
     }
+    console.log(`🪛 ${runeBlockIndexes.length} runestones processed`);
+    if (runeBlockIndexes.length > 0) await runes.saveBlocksInBatch(runeBlockIndexes);
   },
 
   async reorg(height: number) {
-    await runes.resetCurrentBlockHeight(height);
+    await runes.resetCurrentBlock({ height, hash: "" });
   },
 };
-
-// ------------------------------------------
-// UTILS
-// ------------------------------------------
-
-function printBlockInfo(
-  height: number,
-  etchingsLength: number,
-  utxoBalancesLength: number,
-  spentBalancesLength: number,
-  burnedBalancesLength: number,
-  mintCountsLength: number,
-  time: string,
-) {
-  const blockStr = `${height}`.padEnd(6, " ");
-  const etchingsStr = `${etchingsLength.toLocaleString()} etchings`.padStart(12, " ");
-  const balancesStr = `${utxoBalancesLength.toLocaleString()} balances`.padStart(12, " ");
-  const spentStr = `${spentBalancesLength.toLocaleString()} spent`.padStart(9, " ");
-  const burntStr = `${burnedBalancesLength.toLocaleString()} burnt`.padStart(9, " ");
-  const mintStr = `${mintCountsLength.toLocaleString()} mint`.padStart(9, " ");
-  const timeStr = `[${time} seconds]`.padStart(15, " ");
-
-  console.log(`${blockStr}:${etchingsStr},${balancesStr},${spentStr},${burntStr},${mintStr} ${timeStr}`);
-}

--- a/src/Workers/Indexers/Runes.ts
+++ b/src/Workers/Indexers/Runes.ts
@@ -29,6 +29,7 @@ export const runesIndexer: IndexHandler = {
     for (const block of blocks) {
       const runeUpdater = new RuneUpdater(network, block, false, runes, blockchain);
 
+      log(`🔍 [${block.height}] Processing ${block.tx.length} transactions`);
       for (const [txIndex, tx] of block.tx.entries()) {
         await runeUpdater.indexRunes(tx, txIndex);
       }

--- a/src/Workers/Indexers/Runes.ts
+++ b/src/Workers/Indexers/Runes.ts
@@ -21,10 +21,10 @@ export const runesIndexer: IndexHandler = {
     const initialHeight = blocks[0].height;
     const runesIndexHeight = await runes.getCurrentBlock();
     if (runesIndexHeight && runesIndexHeight?.height > initialHeight) {
+      console.log("Runes reorg, new initial height", initialHeight);
       await runes.resetCurrentBlock({ height: initialHeight, hash: "" });
     }
 
-    const runeBlockIndexes: RuneBlockIndex[] = [];
     log(`🔍 Looking for runestones in blocks...`);
     for (const block of blocks) {
       const runeUpdater = new RuneUpdater(network, block, false, runes, blockchain);
@@ -51,11 +51,10 @@ export const runesIndexer: IndexHandler = {
           spentBalances,
           burnedBalances,
         };
-        runeBlockIndexes.push(runeBlockIndex);
+        runes.saveBlockIndex(runeBlockIndex);
         printBlockInfo(runeBlockIndex);
       }
     }
-    if (runeBlockIndexes.length > 0) await runes.saveBlocksInBatch(runeBlockIndexes);
   },
 
   async reorg(height: number) {

--- a/src/Workers/Indexers/Runes.ts
+++ b/src/Workers/Indexers/Runes.ts
@@ -17,15 +17,7 @@ export const runesIndexer: IndexHandler = {
     // order blocks
     const blocks = idx.blocks.sort((a, b) => a.height - b.height);
 
-    // check reorg for runes
-    const initialHeight = blocks[0].height;
-    const runesIndexHeight = await runes.getCurrentBlock();
-    if (runesIndexHeight && runesIndexHeight?.height > initialHeight) {
-      console.log("Runes reorg, new initial height", initialHeight);
-      await runes.resetCurrentBlock({ height: initialHeight, hash: "" });
-    }
-
-    log(`🔍 Looking for runestones in blocks...`);
+    log(`🔍 Looking for runestones in blocks ${blocks[0].height}-${blocks[blocks.length - 1].height}`);
     for (const block of blocks) {
       const runeUpdater = new RuneUpdater(network, block, false, runes, blockchain);
 
@@ -55,6 +47,7 @@ export const runesIndexer: IndexHandler = {
         printBlockInfo(runeBlockIndex);
       }
     }
+    console.log("🏁 Finished looking for runestones");
   },
 
   async reorg(height: number) {

--- a/src/Workers/Worker.ts
+++ b/src/Workers/Worker.ts
@@ -136,7 +136,10 @@ function getWorkerStatus() {
 
 const start = async () => {
   await bootstrap();
-  lastHeight = await db.outputs.getHeighestBlock();
+  lastHeight = config.index.runesOnly
+    ? (await db.runes.getCurrentBlock())?.height || 0
+    : await db.outputs.getHeighestBlock();
+
   if (config.index.maxheight && lastHeight >= config.index.maxheight) {
     console.log(`Already at maxheight ${lastHeight}`);
     process.exit(0);


### PR DESCRIPTION
This PR aims to have a better reorg handling logic for the indexer. 

Main changes:

- Change order of indexers:
  - Reorg logic checks for collection outputs so this indexer must run last. In case of failure or reorg all other indexers will be able to get the correct reorg height and act accordingly.
- Introduced `INDEXER_START_HEIGHT` to allow indexing from a specified block height.
- Simplified and consolidated reorg logic for efficiency.
- Adjusted indexer behavior for `runesOnly` and `startHeight` settings.
- Optimized database models and improved BigInt handling.
- Refactored worker control flow and enhanced logging.
- Added indexer_runner.sh
  - This script handles OOM issues and tries different configurations for the BLOCK_COMMIT_INTERVAL aiming to speed the indexing.
- Added fix for outputHasRunes function.