### PR TITLE
fix(indexer): fix bug on spent outputs reorg logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ dist
 # Logs
 
 npm-debug.log*
+data_validation.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,10 +26,11 @@
         "ioredis": "^5.3.2",
         "lodash.get": "^4.4.2",
         "lodash.mapvalues": "^4.6.0",
+        "lossless-json": "^4.0.2",
         "mongodb": "^6.5.0",
         "node-fetch": "^3.3.2",
         "p-limit": "^4.0.0",
-        "runestone-lib": "git+https://github.com/ordzaar/runestone-lib.git",
+        "runestone-lib": "git+https://github.com/ordzaar/runestone-lib.git#5c298803eb9ce4c97a1fea498ef886888884faa5",
         "tiny-secp256k1": "^2.2.3"
       },
       "devDependencies": {
@@ -49,7 +50,7 @@
         "eslint-plugin-anti-trojan-source": "^1.1.1",
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "husky": "^8.0.3",
-        "lint-staged": "^14.0.1",
+        "lint-staged": "^15.2.10",
         "prettier": "^3.0.3",
         "tsx": "^3.13.0",
         "typescript": "^5.2.2"
@@ -1235,27 +1236,15 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/ansi-escapes": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
       "dev": true,
       "dependencies": {
-        "type-fest": "^1.0.2"
+        "environment": "^1.0.0"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1751,31 +1740,31 @@
       }
     },
     "node_modules/cli-cursor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
       "dev": true,
       "dependencies": {
-        "restore-cursor": "^4.0.0"
+        "restore-cursor": "^5.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-truncate": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
-      "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
       "dev": true,
       "dependencies": {
         "slice-ansi": "^5.0.0",
-        "string-width": "^5.0.0"
+        "string-width": "^7.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1825,12 +1814,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "dev": true,
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/computed-types": {
@@ -1845,9 +1834,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2031,16 +2020,10 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
-    },
     "node_modules/elliptic": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
-      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+      "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -2052,10 +2035,22 @@
       }
     },
     "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "dev": true
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -2341,23 +2336,23 @@
       }
     },
     "node_modules/execa": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
-      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.1",
-        "human-signals": "^4.3.0",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
         "is-stream": "^3.0.0",
         "merge-stream": "^2.0.0",
         "npm-run-path": "^5.1.0",
         "onetime": "^6.0.0",
-        "signal-exit": "^3.0.7",
+        "signal-exit": "^4.1.0",
         "strip-final-newline": "^3.0.0"
       },
       "engines": {
-        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+        "node": ">=16.17"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
@@ -2592,9 +2587,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.0.tgz",
-      "integrity": "sha512-HdWXgFYc6b1BJcOBDBwjqWuHJj1WYiqrxSh25qtU4DabpMFdj/gSunNBQb83t+8Zt67D7CXEzJWTkxaShMTMOA==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
+      "integrity": "sha512-Dobi7gcTEq8yszimcfp/R7+owiT4WncAJ7VTTgFH1jYJ5GaG1FbhjwDG820hptN0QDFvzVY3RfCzdInvGPGzjA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-querystring": "^1.0.0",
@@ -2700,13 +2695,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+    "node_modules/get-east-asian-width": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2903,12 +2910,12 @@
       }
     },
     "node_modules/human-signals": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
-      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "dev": true,
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=16.17.0"
       }
     },
     "node_modules/husky": {
@@ -3219,22 +3226,25 @@
       }
     },
     "node_modules/light-my-request": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.13.0.tgz",
-      "integrity": "sha512-9IjUN9ZyCS9pTG+KqTDEQo68Sui2lHsYBrfMyVUTTZ3XhH8PMZq7xO94Kr+eP9dhi/kcKsx4N41p2IXEBil1pQ==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.14.0.tgz",
+      "integrity": "sha512-aORPWntbpH5esaYpGOOmri0OHDOe3wC5M2MQxZ9dvMLZm6DnaAn0kJlcbU9hwsQgLzmZyReKwFwwPkR+nHu5kA==",
       "dependencies": {
-        "cookie": "^0.6.0",
+        "cookie": "^0.7.0",
         "process-warning": "^3.0.0",
         "set-cookie-parser": "^2.4.1"
       }
     },
     "node_modules/lilconfig": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
+      "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
       }
     },
     "node_modules/lines-and-columns": {
@@ -3244,27 +3254,27 @@
       "dev": true
     },
     "node_modules/lint-staged": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-14.0.1.tgz",
-      "integrity": "sha512-Mw0cL6HXnHN1ag0mN/Dg4g6sr8uf8sn98w2Oc1ECtFto9tvRF7nkXGJRbx8gPlHyoR0pLyBr2lQHbWwmUHe1Sw==",
+      "version": "15.2.10",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.10.tgz",
+      "integrity": "sha512-5dY5t743e1byO19P9I4b3x8HJwalIznL5E1FWYnU6OWw33KxNBSLAc6Cy7F2PsFEO8FKnLwjwm5hx7aMF0jzZg==",
       "dev": true,
       "dependencies": {
-        "chalk": "5.3.0",
-        "commander": "11.0.0",
-        "debug": "4.3.4",
-        "execa": "7.2.0",
-        "lilconfig": "2.1.0",
-        "listr2": "6.6.1",
-        "micromatch": "4.0.5",
-        "pidtree": "0.6.0",
-        "string-argv": "0.3.2",
-        "yaml": "2.3.1"
+        "chalk": "~5.3.0",
+        "commander": "~12.1.0",
+        "debug": "~4.3.6",
+        "execa": "~8.0.1",
+        "lilconfig": "~3.1.2",
+        "listr2": "~8.2.4",
+        "micromatch": "~4.0.8",
+        "pidtree": "~0.6.0",
+        "string-argv": "~0.3.2",
+        "yaml": "~2.5.0"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": ">=18.12.0"
       },
       "funding": {
         "url": "https://opencollective.com/lint-staged"
@@ -3282,59 +3292,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/lint-staged/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/lint-staged/node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/listr2": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-6.6.1.tgz",
-      "integrity": "sha512-+rAXGHh0fkEWdXBmX+L6mmfmXmXvDGEKzkjxO+8mP3+nI/r/CWznVBvsibXdxda9Zz0OW2e2ikphN3OwCT/jSg==",
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.2.5.tgz",
+      "integrity": "sha512-iyAZCeyD+c1gPyE9qpFu8af0Y+MRtmKOncdGoA2S5EY8iFq99dmmvkNnHiWo+pj0s7yH7l3KPIgee77tKpXPWQ==",
       "dev": true,
       "dependencies": {
-        "cli-truncate": "^3.1.0",
+        "cli-truncate": "^4.0.0",
         "colorette": "^2.0.20",
         "eventemitter3": "^5.0.1",
-        "log-update": "^5.0.1",
-        "rfdc": "^1.3.0",
-        "wrap-ansi": "^8.1.0"
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "enquirer": ">= 2.3.0 < 3"
-      },
-      "peerDependenciesMeta": {
-        "enquirer": {
-          "optional": true
-        }
+        "node": ">=18.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -3379,34 +3351,77 @@
       "dev": true
     },
     "node_modules/log-update": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-5.0.1.tgz",
-      "integrity": "sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
       "dev": true,
       "dependencies": {
-        "ansi-escapes": "^5.0.0",
-        "cli-cursor": "^4.0.0",
-        "slice-ansi": "^5.0.0",
-        "strip-ansi": "^7.0.1",
-        "wrap-ansi": "^8.0.1"
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/log-update/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+      "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+      "dev": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
+      "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/log-update/node_modules/strip-ansi": {
@@ -3423,6 +3438,11 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
+    },
+    "node_modules/lossless-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.0.2.tgz",
+      "integrity": "sha512-+z0EaLi2UcWi8MZRxA5iTb6m4Ys4E80uftGY+yG5KNFJb5EceQXOhdW/pWJZ8m97s26u7yZZAYMcKWNztSZssA=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -3517,9 +3537,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
@@ -3555,6 +3575,18 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4260,40 +4292,31 @@
       }
     },
     "node_modules/restore-cursor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
       "dev": true,
       "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/restore-cursor/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/restore-cursor/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
       "dev": true,
       "dependencies": {
-        "mimic-fn": "^2.1.0"
+        "mimic-function": "^5.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4380,8 +4403,8 @@
     "node_modules/runestone-lib": {
       "name": "@magiceden-oss/runestone-lib",
       "version": "1.0.2",
-      "resolved": "git+ssh://git@github.com/ordzaar/runestone-lib.git#6c1d860f7d732c3b300ef2bb23198321f4301cc5",
-      "integrity": "sha512-azlbtNRsjohfCxGSiHMtuSwnU6GdJXAjtojkzKUihGn43huEQtG3D4FELSkoxuFanKSrjNDiyH3DZFk2Yanc0g==",
+      "resolved": "git+ssh://git@github.com/ordzaar/runestone-lib.git#5c298803eb9ce4c97a1fea498ef886888884faa5",
+      "integrity": "sha512-vbxmziCL6z0hR0yIxNgyOHKELw8lA0fYlbfQut4hGjfdGuv/os+Za6Rmtj0e8Xh6H314s3w0gq/WJLWt1PclDw==",
       "license": "ISC"
     },
     "node_modules/safe-buffer": {
@@ -4420,9 +4443,9 @@
       }
     },
     "node_modules/secp256k1": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-      "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.1.tgz",
+      "integrity": "sha512-tArjQw2P0RTdY7QmkNehgp6TVvQXq6ulIhxv8gaH6YubKG/wxxAoNKcbuXjDhybbc+b2Ihc7e0xxiGN744UIiQ==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
@@ -4430,7 +4453,7 @@
         "bn.js": "^4.11.8",
         "create-hash": "^1.2.0",
         "drbg.js": "^1.0.1",
-        "elliptic": "^6.5.2",
+        "elliptic": "^6.5.7",
         "nan": "^2.14.0",
         "safe-buffer": "^5.1.2"
       },
@@ -4493,10 +4516,16 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -4633,26 +4662,26 @@
       }
     },
     "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -5011,26 +5040,26 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
       "dev": true,
       "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -5100,10 +5129,13 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
+      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
       "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
         "node": ">= 14"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "mongodb": "^6.5.0",
         "node-fetch": "^3.3.2",
         "p-limit": "^4.0.0",
-        "runestone-lib": "git+https://github.com/ordzaar/runestone-lib.git#5c298803eb9ce4c97a1fea498ef886888884faa5",
+        "runestone-lib": "git+https://github.com/ordzaar/runestone-lib.git#8554afccebfe9f523f72934f54c2914c1acbe05a",
         "tiny-secp256k1": "^2.2.3"
       },
       "devDependencies": {
@@ -4403,8 +4403,8 @@
     "node_modules/runestone-lib": {
       "name": "@magiceden-oss/runestone-lib",
       "version": "1.0.2",
-      "resolved": "git+ssh://git@github.com/ordzaar/runestone-lib.git#5c298803eb9ce4c97a1fea498ef886888884faa5",
-      "integrity": "sha512-vbxmziCL6z0hR0yIxNgyOHKELw8lA0fYlbfQut4hGjfdGuv/os+Za6Rmtj0e8Xh6H314s3w0gq/WJLWt1PclDw==",
+      "resolved": "git+ssh://git@github.com/ordzaar/runestone-lib.git#8554afccebfe9f523f72934f54c2914c1acbe05a",
+      "integrity": "sha512-I8zdDZbnm5dxQ1+f+IrHpGpfCPARDGFpp+xCWGEho66Vawi0FewDu3/sCtMdtv2Zjle2W46Ek7veXH9P5q+pMQ==",
       "license": "ISC"
     },
     "node_modules/safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "db:start": "docker compose --profile db up -d",
     "db:stop": "docker compose --profile db down",
     "clean": "rm -rf dist",
-    "lint": "eslint ./src --max-warnings 0 --report-unused-disable-directives --fix"
+    "lint": "eslint ./src --max-warnings 0 --report-unused-disable-directives --fix",
+    "datavalidation": "tsx ./src/Workers/Tasks/AddressBalanceValidator.ts"
   },
   "dependencies": {
     "@fastify/cors": "^9.0.1",
@@ -36,6 +37,7 @@
     "ioredis": "^5.3.2",
     "lodash.get": "^4.4.2",
     "lodash.mapvalues": "^4.6.0",
+    "lossless-json": "^4.0.2",
     "mongodb": "^6.5.0",
     "node-fetch": "^3.3.2",
     "p-limit": "^4.0.0",
@@ -59,7 +61,7 @@
     "eslint-plugin-anti-trojan-source": "^1.1.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "husky": "^8.0.3",
-    "lint-staged": "^14.0.1",
+    "lint-staged": "^15.2.10",
     "prettier": "^3.0.3",
     "tsx": "^3.13.0",
     "typescript": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mongodb": "^6.5.0",
     "node-fetch": "^3.3.2",
     "p-limit": "^4.0.0",
-    "runestone-lib": "git+https://github.com/ordzaar/runestone-lib.git#5c298803eb9ce4c97a1fea498ef886888884faa5",
+    "runestone-lib": "git+https://github.com/ordzaar/runestone-lib.git#8554afccebfe9f523f72934f54c2914c1acbe05a",
     "tiny-secp256k1": "^2.2.3"
   },
   "devDependencies": {

--- a/src/Database/Runes/Methods.ts
+++ b/src/Database/Runes/Methods.ts
@@ -123,7 +123,6 @@ async function saveBlockIndex(runeBlockIndex: RuneBlockIndex): Promise<void> {
     mintCounts: runeBlockIndex.mintCounts,
     burnedBalances: runeBlockIndex.burnedBalances,
   };
-  if (sanitizedBlockIndex.mintCounts.length > 0) console.log(sanitizedBlockIndex.mintCounts);
 
   const normalizedBlockIndex = convertBigIntToString(sanitizedBlockIndex);
 

--- a/src/Database/Runes/Methods.ts
+++ b/src/Database/Runes/Methods.ts
@@ -123,6 +123,7 @@ async function saveBlockIndex(runeBlockIndex: RuneBlockIndex): Promise<void> {
     mintCounts: runeBlockIndex.mintCounts,
     burnedBalances: runeBlockIndex.burnedBalances,
   };
+  if (sanitizedBlockIndex.mintCounts.length > 0) console.log(sanitizedBlockIndex.mintCounts);
 
   const normalizedBlockIndex = convertBigIntToString(sanitizedBlockIndex);
 
@@ -147,8 +148,8 @@ async function saveBlockIndex(runeBlockIndex: RuneBlockIndex): Promise<void> {
   }
 
   for (const spentUtxo of runeBlockIndex.spentBalances) {
-    await collectionOutputs.updateOne(
-      { txid: spentUtxo.txid, vout: spentUtxo.vout, runeTicker: spentUtxo.runeTicker },
+    await collectionOutputs.updateMany(
+      { txid: spentUtxo.txid, vout: spentUtxo.vout },
       { $set: { spentTxid: spentUtxo.spentTxid, spentBlockHeight: runeBlockIndex.block.height } },
     );
   }

--- a/src/Database/Runes/Methods.ts
+++ b/src/Database/Runes/Methods.ts
@@ -99,6 +99,10 @@ async function getCurrentBlock(): Promise<BlockIdentifier | null> {
 
 async function resetCurrentBlock(block: BlockIdentifier): Promise<void> {
   await collectionOutputs.deleteMany({ txBlockHeight: { $gt: block.height } });
+  await collectionOutputs.updateMany(
+    { spentBlockHeight: { $gt: block.height } },
+    { $unset: { spentTxid: "", spentBlockHeight: "" } },
+  );
   await collectionBlockInfo.deleteMany({ "block.height": { $gt: block.height } });
   await collectionEtching.deleteMany({ "runeId.block": { $gt: block.height } });
 }
@@ -145,7 +149,7 @@ async function saveBlockIndex(runeBlockIndex: RuneBlockIndex): Promise<void> {
   for (const spentUtxo of runeBlockIndex.spentBalances) {
     await collectionOutputs.updateOne(
       { txid: spentUtxo.txid, vout: spentUtxo.vout, runeTicker: spentUtxo.runeTicker },
-      { $set: { spentTxid: spentUtxo.spentTxid, txBlockHeight: runeBlockIndex.block.height } },
+      { $set: { spentTxid: spentUtxo.spentTxid, spentBlockHeight: runeBlockIndex.block.height } },
     );
   }
 }

--- a/src/Libraries/Indexer/Reorg.ts
+++ b/src/Libraries/Indexer/Reorg.ts
@@ -1,28 +1,11 @@
-import { config } from "~Config";
 import { db } from "~Database";
 import { rpc } from "~Services/Bitcoin";
 
 export async function getReorgHeight(): Promise<number> {
+  // Indexer collection height is updated after all toher indexers.
+  // This ensures all indexers start at the same height
+  // on reindex, reorg or restart.
   const indexerHeight = await db.indexer.getHeight();
   const blockchainHeight = await rpc.blockchain.getBlockCount();
-  // Determine which indexes are active
-  const runesActive = config.index.runes;
-  const outputsActive = config.index.outputs && !config.index.runesOnly;
-
-  let outputHighest = indexerHeight;
-  let runesHighest = indexerHeight;
-
-  if (outputsActive) outputHighest = await db.outputs.getHeighestBlock();
-
-  if (runesActive) {
-    const runesCurrentBlock = await db.runes.getCurrentBlock();
-    if (runesCurrentBlock) runesHighest = runesCurrentBlock.height;
-  }
-
-  const lowestHeight = Math.min(outputHighest, runesHighest, indexerHeight);
-
-  if (lowestHeight > blockchainHeight) return blockchainHeight;
-
-  // If no reorganization is needed, return -1
-  return -1;
+  return indexerHeight > blockchainHeight ? blockchainHeight : -1;
 }

--- a/src/Workers/Indexers/Runes.ts
+++ b/src/Workers/Indexers/Runes.ts
@@ -43,7 +43,7 @@ export const runesIndexer: IndexHandler = {
           spentBalances,
           burnedBalances,
         };
-        runes.saveBlockIndex(runeBlockIndex);
+        await runes.saveBlockIndex(runeBlockIndex);
         printBlockInfo(runeBlockIndex);
       }
     }

--- a/src/Workers/Tasks/AddressBalanceValidator.ts
+++ b/src/Workers/Tasks/AddressBalanceValidator.ts
@@ -1,0 +1,149 @@
+import fs from "fs";
+import { isInteger, parse } from "lossless-json";
+import pLimit from "p-limit";
+import path from "path";
+import { exit } from "process";
+import { RuneUtxoBalance } from "runestone-lib";
+
+import { config } from "~Config";
+import { db } from "~Database";
+
+async function main() {
+  try {
+    const ORD_URI = config.ord.uri;
+    const discrepancies: Array<{
+      dbTxid: string;
+      dbVout: number;
+      runeTicker: string;
+      dbAmount: string;
+      ordAmount: string;
+    }> = [];
+
+    const BATCH_SIZE = 100;
+    const CONCURRENT_REQUESTS = 5;
+    let notFoundCount = 0;
+    let batchCount = 0;
+
+    const logFilePath = path.join(__dirname, "ord_not_found_log.txt");
+    fs.writeFileSync(logFilePath, "ORD Not Found Log:\n", "utf-8");
+
+    console.log("BATCH_SIZE:", BATCH_SIZE);
+    console.log("CONCURRENT_REQUESTS:", CONCURRENT_REQUESTS);
+
+    const limit = pLimit(CONCURRENT_REQUESTS);
+
+    const cursor = db.runes.collectionOutputs.find({
+      spentTxid: { $exists: false },
+    });
+
+    const totalDocuments = await db.runes.collectionOutputs.countDocuments({
+      spentTxid: { $exists: false },
+    });
+    const totalBatches = Math.ceil(totalDocuments / BATCH_SIZE);
+
+    while (await cursor.hasNext()) {
+      batchCount++;
+      const batch: RuneUtxoBalance[] = [];
+
+      for (let i = 0; i < BATCH_SIZE; i++) {
+        if (await cursor.hasNext()) {
+          const doc = await cursor.next();
+          if (doc) {
+            batch.push(doc as RuneUtxoBalance);
+          }
+        } else {
+          break;
+        }
+      }
+
+      if (batch.length === 0) {
+        break;
+      }
+
+      const progress = ((batchCount / totalBatches) * 100).toFixed(2);
+      process.stdout.write(`\rProcessing... ${progress}%`);
+
+      const tasks = batch.map((doc) =>
+        limit(async () => {
+          const txid = doc.txid;
+          const vout = doc.vout;
+          const outputUrl = `${ORD_URI}/output/${txid}:${vout}`;
+
+          try {
+            const response = await fetch(outputUrl, {
+              method: "GET",
+              headers: {
+                Accept: "application/json",
+              },
+            });
+
+            if (!response.ok) {
+              console.error(
+                `Failed to fetch ORD data for txid ${txid} vout ${vout}: ${response.status} ${response.statusText}`,
+              );
+              return;
+            }
+
+            const ordData: any = parse(await response.text(), null, (value) => {
+              if (isInteger(value)) return BigInt(value);
+            });
+
+            const processedRunes: any = {};
+            for (const [key, value] of Object.entries(ordData.runes)) {
+              const cleanedKey = key.replace(/•/g, "");
+              processedRunes[cleanedKey] = value;
+            }
+
+            const ordRune = processedRunes[doc.runeTicker];
+            if (!ordRune) {
+              notFoundCount++;
+              fs.appendFileSync(logFilePath, `${txid}:${vout}[${doc.runeTicker}]: not found in ord index\n`, "utf-8");
+              return;
+            }
+
+            const ordAmount = ordRune.amount;
+            if (ordAmount > 100000000000000000000000000000n) console.log(ordAmount);
+
+            if (BigInt(doc.amount) !== ordAmount) {
+              discrepancies.push({
+                dbTxid: txid,
+                dbVout: vout,
+                runeTicker: doc.runeTicker,
+                dbAmount: doc.amount.toString(),
+                ordAmount: ordAmount.toString(),
+              });
+            }
+          } catch (error) {
+            console.error(`Error fetching from ord server:`, error);
+          }
+        }),
+      );
+
+      await Promise.all(tasks);
+    }
+
+    process.stdout.write("\rProcessing... 100% - Completed.\n");
+
+    if (discrepancies.length > 0) {
+      console.log("Discrepancies found:");
+      discrepancies.forEach((discrepancy, index) => {
+        console.log(`${index + 1}. Txid: ${discrepancy.dbTxid}, Vout: ${discrepancy.dbVout}`);
+        console.log(`   RuneTicker: ${discrepancy.runeTicker}`);
+        console.log(`   DB Amount: ${discrepancy.dbAmount}`);
+        console.log(`   ORD Amount: ${discrepancy.ordAmount}`);
+      });
+    } else {
+      console.log("No discrepancies found.");
+    }
+
+    console.log(`Total not found in ord index: ${notFoundCount}`);
+    console.log(`Detailed 'not found in ord index' log can be found at: ${logFilePath}`);
+  } catch (error) {
+    console.error("An error occurred in the main function:", error);
+  } finally {
+    console.log("Exiting process...");
+    exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
This PR fixes the spent outputs reorg logic.
- Since the spending of outputs updated the txBlockHeight, on reorg, the spent outputs where deleted instead of marking them as spendable again.
- Also the PR simplifies the reorg logic since the previous logic was unnecessary.